### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -188,11 +188,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1679355988,
-        "narHash": "sha256-2FSznhI7ugRQjQ2MvF8qS7YBmgZMtZuDamhzqg6IfOg=",
+        "lastModified": 1679412343,
+        "narHash": "sha256-1+lHE1dZKXFn5P6LVi7B9rCu/XddjL5lS650vYIsVWQ=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "313f7145e52d62303e730d2ac30f418b45d30a60",
+        "rev": "d04ad1577cc1c4bf67dbe209f40d6dcf2d819dc0",
         "type": "gitlab"
       },
       "original": {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/3658a90db8c319b7d8a24b9353cf0d2b979229bc"><pre>Scoru,Proto: put cemented commitment in operation result</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e4d2c0ea5a8fb95f416d1cfa184de390f40f9c59"><pre>Scoru,Proto: deprecate [commitment] field from [Sc_rollup_cement]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4c13f766ac811362ed3616f890f630486aaafcc4"><pre>Merge tezos/tezos!7316: Scoru,Proto: deprecate [cement] parameter from [Smart_rollup_cement]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bb54f0c9f2a49785ff4c99321de1263a4141a841"><pre>Scoru, Tests: add operation generator for generative tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fe76698e63eb1da88b0dbd5a76662386b8b0a27e"><pre>Merge tezos/tezos!7728: Scoru, Tests: add input generator for durable generative tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6dec0cdb7b2473c96c9691e1e4b7bf4f2c2ea8a2"><pre>Proto/validate: remove unused block/payload_producer from mode infos</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4bdbee303bb1cf817323dd85c213fcd9a65de7d6"><pre>Proto/validate: further factorize endorsement power check</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/93e8edcebb0a9c92f47c7cbb80cdba76b32cf0fe"><pre>Proto: move block header finalization checks to validate</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/261f1844e5d40895fc8540449479d03343c63a93"><pre>Proto/validate: only check fitness locked round in application mode</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/361f30495e2a435e4ea76147ccecde2b632ea1e2"><pre>Proto/validate: isolate preendorsement final checks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b54e240b8e3bb159ebc5895c11193da5b8c98170"><pre>Proto/validate: simplify payload hash check</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cd4b724119521d2a6b2662c840f83f9a6075db14"><pre>Proto/validate: check preendorsement power and locked round also in</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ff7fb6381fb1a8a834eb26eb47455bebcf154e66"><pre>Changelog: add entry</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d729cc1d611c5e976664effffabbae02b846f4fc"><pre>Merge tezos/tezos!7949: Proto/validate: refactor block finalization and add checks in partial validation mode</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/75c7b4d893a29f9cde11a7b0d9e8fc1d9c650c46"><pre>EVM/Kernel: enforce hexadecimal in lowercase before building path</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1d540ff239d9989ab670df5db1dcf2819c2ee956"><pre>EVM/Kernel: rationalize storage ownership</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5a7109f6a99d518722f18c1d13c40357c0eb5510"><pre>EVM/Kernel: validation returns the sender\'s parameters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0dde24ec96c6270fb572d96f344abb861c3e7bec"><pre>Merge tezos/tezos!8058: EVM/Kernel: validation returns the sender\'s parameters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7cbb3386281515b813c5fed84eb9026333548ab3"><pre>Proto/Scoru: typed outbox</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9652f926767bc181095d00e488d4855610567b1b"><pre>soru/client: add transaction parameters encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6d423ab47ff331c7dd1a603419ae9bf4529c8bd7"><pre>soru/tezt: add test for typed outbox parameters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/adbd002cfe5fa6404f5bd974718b01fa3b3e1c81"><pre>soru/test: test encode/decode of typed outbox message</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1efef934c33d0ea844cc3ef08a5173d08e3a9040"><pre>soru: update changes doc for typed transaction</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9a5fd52de72c238cccf9622681723c5444fd9055"><pre>Merge tezos/tezos!7941: Add type to smart rollup outbox message</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7ceee7b69bc9da857d826e79f4eedf5dbe04856d"><pre>Alcotezt-UX:rename headers [lib_client/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3abc2b0b453b920ae04a6ee0bf20e06ae322302a"><pre>Alcotezt-UX:rename headers [lib_clic/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/98fb9c762a775a6a22ff2947e73bb5f0b39e9c21"><pre>Alcotezt-UX:rename headers [lib_client_base/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6116818fc2016ce0cb2602f1a9f85c1fcc618c26"><pre>Alcotezt-UX:rename headers [lib_client_base_unix/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e4cb4767d4a18ef421addf0bdc1c449b5e8e851b"><pre>Alcotezt-UX:rename invocation [lib_context/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e347d04275867e1f4a2e7638bb22f277044c1813"><pre>Alcotezt-UX:rename invocation lib_crypto/[test],[test-unix]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f03a56db6aea4dedebc5772f6a3249bf987612ea"><pre>Alcotezt-UX:rename invocation [lib_error_monad/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/77eceb998c6758ff73b93bff7608feb680c6ed28"><pre>Alcotezt-UX:rename invocation [lib_mockup/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/816c1ad79a0277d45ffaaadafc1ebffd7b877169"><pre>Alcotezt-UX:rename invocation lib_pro_env/[test],[test_shell_context]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/242e3bff1d749599e3c9eb6dbc779fff9d98e435"><pre>Alcotezt-UX:rename invocation lib_proxy/[test],[test_helpers]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7c009f1a79ae394d3fb03ac928386aea66460e99"><pre>Merge tezos/tezos!8003: Alcotezt-UX: rework on invocation headers I</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e2369a8d0e15448c9ba10fff85d3ce4062f29ab4"><pre>Tezt: Do not depends on old protocols</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/45f1c83f7b4ca435590d4cb611dcb060d151d54d"><pre>Merge tezos/tezos!8131: Tezt: Do not depends on old protocols</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1a0bc88b66d8401b95c73b061fc4856ef112c10e"><pre>CI: Remove old protocols before snapshotting</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d04ad1577cc1c4bf67dbe209f40d6dcf2d819dc0"><pre>Merge tezos/tezos!8133: CI: Remove old protocols before snapshotting</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/313f7145e52d62303e730d2ac30f418b45d30a60...d04ad1577cc1c4bf67dbe209f40d6dcf2d819dc0