### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -188,11 +188,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1679412343,
-        "narHash": "sha256-1+lHE1dZKXFn5P6LVi7B9rCu/XddjL5lS650vYIsVWQ=",
+        "lastModified": 1679466969,
+        "narHash": "sha256-p7WC89NslfiX9AxWKPbaGisy/bCk4FClVfTgsM0CKLY=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "d04ad1577cc1c4bf67dbe209f40d6dcf2d819dc0",
+        "rev": "2ad88ac95b5ad5cf68a7f8876a1f884482ada245",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230321";
+    octez_version = "20230322";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/d6bc8fb969132fe3bf396d73333c50987cd1add2"><pre>Docs, v16: Add opam clean to build recipe</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ea8756a2c7c190c245248ea288c542c4eb7fa200"><pre>Merge tezos/tezos!8135: Docs, v16: Add opam clean to build recipe</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a41993ab38366b9ecefefab1bdfa3cd7f8343208"><pre>doc: fix address of ledger in key-management.rst</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a01a41fd3dca2016a916d7447e9ee5d84fb544dc"><pre>doc: fix error in smart_rollups.rst</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f3260941214706f2292235f932ae2f0932af2011"><pre>doc: fix spelling error DailyNet => Dailynet</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9052ee9f19c5d75aac0d73cdb70a1f3df8349952"><pre>doc: gitignore generated manual for proxy-server</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/58fdcd53dde86150eac1f59c96ac6f7f1eba369e"><pre>doc: fix typos in key_management</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fa9236841f9a58168e11757c62510fb34eb07926"><pre>doc: add option to test signature onledger</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eb3adb8e7478181b8096535dbde008b28bfcdbdd"><pre>doc: warn users that storage reconstruction may last weeks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0a5c2df80db2bdd2dd3aaf3ff3adbe620f94761f"><pre>doc: fix a few broken links</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/84f92bb982871a1dca186b7885c00c1c23661884"><pre>Doc: more details about node reconstruction</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f6853f9c827cb2d2d6e77229f9331d8d8afdb69e"><pre>Doc: fix typos in Michelson docs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b28550300f459faa109301b85c64adbe02e6df76"><pre>Doc: fix typos in SCORU docs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/62d916bae07a0c46033387ef0c2d59990646814c"><pre>doc: remove section on one-shot tests (abandoned)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/af34fed7fa0239fd79d2f992c7edd581dc918954"><pre>doc: typos in protocol_overview</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c9059532ec017e7d652bbd50182dc46bd071bb3a"><pre>doc: better instructions for updating to v16</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/50dbd130c701de455b1efff602d4f16d514c217c"><pre>Merge tezos/tezos!7775: doc: Typo train</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/783f44096d654d48753ef35b3ad6c8b2c5e8bccc"><pre>EVM/Kernel: craft receipts for genesis\' mint transactions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eae9392d1df568ba9d5c64d292bf3f2786d8fe8d"><pre>Merge tezos/tezos!8119: EVM/Kernel: craft receipts for genesis\' transactions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/34aa6125bf6af11650f76568659c6c8bf77585f7"><pre>SDK: Allow to choose the native targets of executables with a variable</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dfe5fc1f72e37ae0bbf729447c57f411e2fdd1e3"><pre>Merge tezos/tezos!8114: SDK: Allow to choose the native targets of executables with a variable</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8b6c6b4bc9a62eb297db0801025ba1a90b3fbf57"><pre>bin_snoop: change workload dump command to print to stdout</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2ad88ac95b5ad5cf68a7f8876a1f884482ada245"><pre>Merge tezos/tezos!8092: Snoop: change workload dump command to print to stdout</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/d04ad1577cc1c4bf67dbe209f40d6dcf2d819dc0...2ad88ac95b5ad5cf68a7f8876a1f884482ada245