### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -72,11 +72,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679262748,
-        "narHash": "sha256-DQCrrAFrkxijC6haUzOC5ZoFqpcv/tg2WxnyW3np1Cc=",
+        "lastModified": 1679437018,
+        "narHash": "sha256-vOuiDPLHSEo/7NkiWtxpHpHgoXoNmrm+wkXZ6a072Fc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "60c1d71f2ba4c80178ec84523c2ca0801522e0a6",
+        "rev": "19cf008bb18e47b6e3b4e16e32a9a4bdd4b45f7e",
         "type": "github"
       },
       "original": {
@@ -188,11 +188,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1679466969,
-        "narHash": "sha256-p7WC89NslfiX9AxWKPbaGisy/bCk4FClVfTgsM0CKLY=",
+        "lastModified": 1679535521,
+        "narHash": "sha256-up00BhjnApBG52tuR2KzHxCHuaGyMNlSTvJAyhJA9Ac=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "2ad88ac95b5ad5cf68a7f8876a1f884482ada245",
+        "rev": "3b485961d93420225794101607f3f3a50d3828ee",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230322";
+    octez_version = "20230323";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/dcea00bdbf8ccac4dc7bd6766b119375fd216925"><pre>Benchmarks: move some registration helpers to a new module.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/591457193a51cf791b43ff51da6a73fac5c2c9a3"><pre>Benchmarks: rename Benchmark_simple to Benchmark.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1f8e36180fd43eb2a6e8c96aeed9ec6b7f4e0adf"><pre>Benchmars: rename register_simple to register.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ae2c7363e140303e024e6c0b9dd952e79f9908d3"><pre>Benchmarks: adapt a benchmark to the new helper module.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d4d4afc324ae39dae85d6f92f7837ca642750d05"><pre>Benchmarks: create a registration helper sub-module.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b2bbaad2cffc0f308fb72bf62c68418e871453d3"><pre>Benchmarks: make fmt-ocaml.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d9a2d50945ea05746b22506d78ab07c2c12efc21"><pre>Benchmarks: interface for the helper module.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ae1ac1d76aee175e15f9e07af9a659982a29162c"><pre>Merge tezos/tezos!7847: Benchmarks: new helper module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0e70b38743ce31089e5151b476baa0396d0ec8cf"><pre>DAL/GS: start implementing a GS worker: initial interface</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c142d6c69d644a33f08a2310c15553ec0d6eeed9"><pre>DAL/GS: start implementing a GS worker: initial implementation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0331f1b39a63765be517db580d9993e75f70e399"><pre>Merge tezos/tezos!8116: DAL/GS: start implementing a GS worker</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e283f049b4a7a2cb61443237fbbeaf1607fb457e"><pre>src/lib_base/test_helpers/: improve error message on [tztest] failures</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/54d4dc8f692887a9a18c96fb5fd4e9a8914e3d85"><pre>Merge tezos/tezos!8144: src/lib_base/test_helpers/: improve error message on [tztest] failures</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8514586377c590a1207696353a56346987aa1058"><pre>Benchmarks: add a Model helper sub-module.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9bab48b941bbc83069375cdc86b17f3157ce44e5"><pre>Benchmarks: Model.make transfers the benchmark name to the model.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d71a8ce801d357d59650902f30ac8238f9880420"><pre>Benchmarks: register transfers the benchmark name to the Model.make.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cb1f559e368c9429e50131af24bc675ff4cd65bb"><pre>Benchmarks: make parameters optional for some models.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fd4818911028869fc933d7bf7832dc26a428ffd9"><pre>Benchmarks: system decides some gas parameter names.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bf5f00b0378b04dc3a9f64cba96355f714adcad4"><pre>Benchmarks: format code.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/08d9ddcb32acddcdcfb7a047fa223ec66d4889fe"><pre>Merge tezos/tezos!7850: Benchmarks: simplify models</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/222f49d34f6e86f4640dd32b18bb541773692bdd"><pre>Alcotezt-UX: fix invocation headers II</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b5025e2bd774286e99751f536666341aebc448fe"><pre>Merge tezos/tezos!8117: Alcotezt-UX: fix invocation headers II</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0396bc8890aeebba56068c663bce78735c055010"><pre>Injector: ignore operations which already exist when adding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/487e5431a809d6e0c31976bd985ee056043242a9"><pre>Merge tezos/tezos!8106: Injector: ignore operations which already exist when adding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/39ff241e871cc87a99bb2a7e0ec6345a4c74353a"><pre>Scoru: Fix FE inbox/outbox recovery on exception</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0080ee1bc70d206e5201980b87cfee64748977e2"><pre>Merge tezos/tezos!8083: Scoru: Fix FE inbox/outbox recovery on exception</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a5c1eaa1b02258921f35a262acd4ad82d7aeaa9e"><pre>Tezt/self_test: fix [test_michelson_script.ml] test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cb5c8d847e877bd839bea27d306406a9da3c5ea5"><pre>Tezt/self_test: remove upstreamed tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d7aea3571dcdc977257a594a92ccca7997dfa985"><pre>Merge tezos/tezos!8047: Tezt: remove upstreamed self tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5e2ed1979dc8acba0f980615b5046420c6b61c49"><pre>Proto/Michelson: always check annotations first in parse_ty</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b0fb5128a21558a14c94b43673beea152b803c51"><pre>Merge tezos/tezos!8104: Proto/Michelson: always check annotations first in parse_ty</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0235bb890754c5c7afc9a93c51f2e6b6a93ff5df"><pre>Proto/script_typed_ir, Michelson: Simplify ty_traverse</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f885ef15367dffb41a59a71790510b2d4e692ab2"><pre>Proto/script_typed_ir, Michelson: update doc of traverse functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e75944180ada9bbd093da0915e4892e34a623c77"><pre>Merge tezos/tezos!8145: Proto/script_typed_ir, Michelson: Simplify ty_traverse</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a8d2dfd648cc760b82bf47a8743694541c778ee4"><pre>WASM: Have the Fast Exec enable host functions per WASM PVM revision</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/38342a1a4b350a6bcae21abae96c5b03b4f41088"><pre>Merge tezos/tezos!8079: WASM: Have the Fast Exec enable host functions per WASM PVM revision</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/73527342f3102829f81692b4d051109e6b66f446"><pre>Proto/Env v8: implements fold_right_es as fold_left_es @ rev</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/558c05620ba1ccb2dd10884baf878e6ff1b105c0"><pre>Merge tezos/tezos!8149: Proto/Env v8: implements fold_right_es as fold_left_es @ rev</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3cdb18e917c609a19d843f3b3525bbd7232d23b2"><pre>Alpha/Baker: fix delayed prequorum preventing endorsements</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/386ebd137bb20b90f8cac9de502df60d5a635a4a"><pre>Alpha/Baker: test that delayed prequorum correctly reset</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e0734d1adcbeb5e0f91f1ae1d677ff988488a452"><pre>Mumbai/Baker: backport delayed prequorum fix and test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8ca38be78c9ab28858c57c5b65257e02216c007d"><pre>Changelog: add a fix entry</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ce0531fe65c59a886dfe68e5c5b40d0267204ae6"><pre>Merge tezos/tezos!8158: Fix delayed prequorum blocking endorsing action</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a5825b13fa60dd51583e002a1c6cf73f318b52a3"><pre>Fixes the intercept points of lsl_bytes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3b485961d93420225794101607f3f3a50d3828ee"><pre>Merge tezos/tezos!8020: Fixes the intercept points of lsl_bytes</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/2ad88ac95b5ad5cf68a7f8876a1f884482ada245...3b485961d93420225794101607f3f3a50d3828ee