### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -188,11 +188,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1679535521,
-        "narHash": "sha256-up00BhjnApBG52tuR2KzHxCHuaGyMNlSTvJAyhJA9Ac=",
+        "lastModified": 1679629711,
+        "narHash": "sha256-lOfebHMqqhEs81EvG9SWHaiuXMe3GXnZz7h0hU/PAXk=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "3b485961d93420225794101607f3f3a50d3828ee",
+        "rev": "f00fadb9842cd553c2a32980d87758f6a13dcc9e",
         "type": "gitlab"
       },
       "original": {
@@ -208,11 +208,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678901796,
-        "narHash": "sha256-9myDjq948gHbiv16HnFQZaswQEpNodE/CuGCfDNnv/g=",
+        "lastModified": 1679588014,
+        "narHash": "sha256-URkRSunu8HAp2vH2KgLogjAXckiufCDFrBs59g9uiLY=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "0f560a84215e79facd2833b20bfdc2033266f126",
+        "rev": "af75d6efe437858f9ca5535e622cfbedad1ba717",
         "type": "github"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230323";
+    octez_version = "20230324";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/095949206d765e58aaa4867e51d6c4d4ea1d9de3"><pre>sdk: forbid readonly path</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f480cb3a53493bcfcbba6733fad3db6e50c2af02"><pre>sdk: add runtime fct for is_stuck</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/99002be4a50a37e9ea88a8a4558bde7e005f7c2f"><pre>sdk: add runtime fct for upgrade_error flag</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e993f12a702a55974804c1ab12bf1506dfed3bec"><pre>sdk: add runtime fct for too many reboot flag</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5c9d2eb1367f6f3d0ada54dbc8eab7dd47b18857"><pre>sdk: add runtime function for reboot counter</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/024429e0750167262b054c1117e2cfe51415201b"><pre>sdk: add runtime fct for version</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8db901855ba11a4602faa3efc30cb011306db6ab"><pre>Merge tezos/tezos!8136: soru: SDK add pvm error</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2e1212a46477c7863d48b626c0f5d2f9d6233532"><pre>p2p: reduce verbosity of all p2p unit tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3da25a3d62795800b0c7128f0546c5723cc7883e"><pre>p2p: tests. update invocation headers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bf03b3b30b518d615c0b34ed8a4ef00bc331c27f"><pre>lib_p2p: port tests to alcotezt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/805471f0fa9abbe65b63f2fedcf7bce7d28733bb"><pre>p2p: use ::1 as ipv6 localhost</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7268205fa6a624f4ea1f5b11fa63f0dfed4b5b57"><pre>Merge tezos/tezos!7997: p2p: port all tests to alcotezt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c9c28c9b83bcff76055d27209b7456e6d5f1f7e4"><pre>Alcotezt-ux: fix invocation headers III</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/101c2fe20e4f4c621e5383cdf21ef4a869b1944f"><pre>Merge tezos/tezos!8118: Alcotezt-ux: fix invocation headers III</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4fbb32e5c4c814afa15a692ce6e863b4cabe5d4d"><pre>Gossipsub: merge last_published_time within fanout</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/10398cf4e3e2dedb4c4e2a798b9bb7639ffec226"><pre>Gossipsub: delete expired fanout topic during heartbeat</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6c8462d426f98a861192d018b6e5c0eca17e66dd"><pre>Merge tezos/tezos!8134: Gossipsub: expire fanout topics</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7a16248f619625605648992d71de080939f61145"><pre>XDG: add XDG_path module to deal with XDG specs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c64a0ac0ed1b841696edc41f23fed5ba3d391c6e"><pre>Logs: set default daily logs directory at XDG specified path</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/780416d024d3cc4ff947b70f2b02da9646156e58"><pre>Merge tezos/tezos!7849: Node/logs: use XDG Specification to select daily logs location</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9b04ced7bf2bef3db50eb050363d120105443aba"><pre>Revert \"Merge tezos/tezos!7997: p2p: port all tests to alcotezt\"</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7282b78aa7153c1f7308c6745546c9774ccd03ff"><pre>Merge tezos/tezos!8184: Revert \"Merge tezos/tezos!7997: p2p: port all tests to alcotezt\"</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2e90aaf31bb532685be9db433d775275c4f6d0b8"><pre>Gossipsub/test: add deps to qcheck</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e80ad5705a5a37376653c477944f5a958128d3c2"><pre>Gossipsub/test: factor config in dedicated file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/69b9706c27e5b811ebe1ae6b326892f1479c54b6"><pre>Gossipsub/test: allow to manually elapse time</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b22dffbb90fdfea8b0835a28ee0a8e3d1713c4de"><pre>Gossipsub: add Internal_for_tests exposing connections</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6553ae78485fd96986de4cec82c6bdaedba6b936"><pre>Gossipsub: explicit input types for automaton</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/42cfb0c893b611f222cc0e40c5e2988d93901edd"><pre>Gossipsub/test: PBT helpers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/38e795f3ce4030f33233a276cd40af7ead2e7659"><pre>Gossipsub/test: test add_peer/remove_peer control msgs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f16e076ed56e4f9d56159e28735936b0d820e618"><pre>Gossipsub: fix bugs in heartbeat</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1fb8d45848a54fd56b1f08998f6134bb67d625a5"><pre>Gossipsub/test: split pbt and unit tests in distinct files</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/28d9166331f9c03f43b59641013fdd58c85005f4"><pre>Gossipsub/test: add printer for limits</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7ef6c1640056ed5316fcc036509f3ef1ea74ba86"><pre>Gossipsub/test: improve PBT</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9c9d80d0d9b4771aaf5f75878c18808ce67c1ed7"><pre>Merge tezos/tezos!8030: PBT helpers for gossipsub implementation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3ac4be4a5aa1265cd1ba0aaa46f45baf7577597e"><pre>Alcotezt-ux: rename tags</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/524fc30662e8d59c6f8792c736831aa1f2a07f9f"><pre>Merge tezos/tezos!7999: Alcotezt-ux: rename tags</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2f042e7ccb6864621e14a1d5a653d92c4daa63d6"><pre>SCORU/Node/Alpha: replace exit in initial state hash by error in the monad</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4c3037b1c7830a8b81f251bbcee1aaa31dd871f2"><pre>SCORU/Node/Mumbai: replace exit in initial state hash by error in the monad</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eabf734768ef718f2cc8b51bf5cb8baed5978bf5"><pre>Merge tezos/tezos!8142: SCORU/Node: replace exit in initial state hash by error in the monad</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/38886f8fa1c4478b5d00ce515b23f4947cc984b8"><pre>Alcotezt-ux: add missing invocation headers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/af4fb692828442d607242250e1725c958530d2f2"><pre>Merge tezos/tezos!8140: Alcotezt-ux: add missing invocation headers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b59d0cf18e45368fd407ef233f2dcfedf32abfa8"><pre>Docs, Changelogs: Snapshot for Octez v16.1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a6ed8ecd31de5e0e72c708adc95507d72fa145c7"><pre>Docs, Releases: Update release page for Octez v16.1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7b93b4dc21a0ed889c9281a1493eff3ac51a03a5"><pre>Docs, Openapi: Update specification for Octez v16.1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9aa7e160d431517c3e4aa73fd435bec334c2334d"><pre>Merge tezos/tezos!8174: v16.1: Documentation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/173f6921f380741d531ff86413a7dfaf0d268859"><pre>soru/tezt: refactor scenario test title</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/db3d214d98b45399ef367e99283e6fd932d65517"><pre>Merge tezos/tezos!8185: soru/tezt: refactor scenario test title</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/01c7f2515fdb7ebd8998ab0bc6690631911e73cf"><pre>lib_delegate: split test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3134c5691480d14db3dfc29df59a02bacb25a583"><pre>lib_delegate: rename test suite</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3d7893685fa7b918d835e5fd7264c3d13e994b4f"><pre>Merge tezos/tezos!8129: lib_delegate: split test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5d3e8ddf57198fa7145727b3e20824f989aba4e6"><pre>CI: Don’t cache _build/ in build jobs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eedff4587ff8e7f918881f16e23d15cfbd4eecd9"><pre>Merge tezos/tezos!8165: CI: Don’t cache _build/ in build jobs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8cf0b664b2280a484859c9f0bb06a333b46ce353"><pre>Store: improve storage upgrade errors</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/29b3bbf550cbb252a680ac8c37b55ee505c9049e"><pre>Merge tezos/tezos!8187: Store: improve storage upgrade errors</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/efbe029efa2a6158e6ed8f17bb673c0fbdf99fff"><pre>DAC: transform keys 3-tuple to record</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/89be6f3da9ced912a6af6eccf03b8acbdabf78eb"><pre>DAC: provide DAC node PKH to sign root hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/410464e9fe63afcd5bc8c4f36a452ff2c55ff7cc"><pre>DAC: provide Node PKH via command argument</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6d8f7b71c50668bf2ae005b4be99b0d6412b01ba"><pre>DAC: extract wallet and keys only once</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/73fa0b2d589774c41d7bbab02bc72fd2547b9d15"><pre>DAC: emit event when no commitee_member_address</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0f22a6859d7980efa036e6e0c0fe5f6e90cb3f13"><pre>DAC: Dac_manager.Keys.t is now private</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8289e29cd5ab8bd8214d29d0b24b0cacd4a5b146"><pre>Merge tezos/tezos!7894: DAC: Member signs root page hashes and post it to coordinator</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c40da51111eb026fc5b4835aef134159c9af5ab4"><pre>Gossipsub: use \'inject\' for routing application layer messages</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/316d1831d76d909b3aa97c4e55cb5309ebb54eb8"><pre>Merge tezos/tezos!8181: Gossipsub: use \'inject\' when routing messages from the application layer</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/94135c847580d58b7b9c5dd0281803895ca25331"><pre>Gossipsub: Fix bug where fanout peer can be doubly selected</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ef6f01700a2f7ee1ab7f47c614886ffb2daf890e"><pre>Gossipsub: Expose topic mesh and fanout for testing purpose</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/11098cfcac02efd0a35a869c372dd24c79259b01"><pre>Gossipsub/Test: Rework [init_state] function in test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/296ff919662618104cde3f230e23053c264eb814"><pre>Gossipsub/Test: Port [test_join] from rust-libp2p</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5bd2a4f95c1c62bd69ac63b25f346895a5e20fbb"><pre>Merge tezos/tezos!8095: Gossipsub/Test: Port test_join from rust-libp2p</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8a980f99acd67f6faa3b7e3f3990706b968c4e1c"><pre>Proto: moves the hand-edited cost functions to michelson_v1_gas_costs.ml</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/618c60bbe80925e9d196c92a8cad1f5e4855f598"><pre>Snoop: added \"check definitions of\" command</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c95d7209d95c7aebc86c7d4320d5c671d86f2ec1"><pre>Tezt/Snoop: runs cost function definition check</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f00fadb9842cd553c2a32980d87758f6a13dcc9e"><pre>Merge tezos/tezos!7530: Move hand edited gas cost functions to michelson_v1_gas_costs.ml</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/3b485961d93420225794101607f3f3a50d3828ee...f00fadb9842cd553c2a32980d87758f6a13dcc9e