### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1678379998,
-        "narHash": "sha256-TZdfNqftHhDuIFwBcN9MUThx5sQXCTeZk9je5byPKRw=",
+        "lastModified": 1679737941,
+        "narHash": "sha256-srSD9CwsVPnUMsIZ7Kt/UegkKUEBcTyU1Rev7mO45S0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c13d60b89adea3dc20704c045ec4d50dd964d447",
+        "rev": "3502ee99d6dade045bdeaf7b0cd8ec703484c25c",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1679437018,
-        "narHash": "sha256-vOuiDPLHSEo/7NkiWtxpHpHgoXoNmrm+wkXZ6a072Fc=",
+        "lastModified": 1679797994,
+        "narHash": "sha256-Kr/O/UlfqAtoFmkZeAaphsxogeaN8a/IugBApFzPfpk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "19cf008bb18e47b6e3b4e16e32a9a4bdd4b45f7e",
+        "rev": "5f9d1bb572e08ec432ae46c78581919d837a90f6",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1679661643,
-        "narHash": "sha256-jBx/cSJ0zXZJH6roMUuFjBQxQBroxd4Gz1n4xRZCGoY=",
+        "lastModified": 1679752074,
+        "narHash": "sha256-nc4DQ4gpc8+6HCewdo+SmVLICjcRq/EzmhP0ZMGQHyg=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "3b517d3669d7b7515b7de62a81197862d35b3d22",
+        "rev": "0a528bd1800628af6027b93ce89c95799e2f9d00",
         "type": "gitlab"
       },
       "original": {

--- a/nix/release/overlays.nix
+++ b/nix/release/overlays.nix
@@ -280,6 +280,8 @@
             sha256 = "sha256-cfsSVmN4rbKcLcPcy6NduZktJhPXiVdK75LypmaSe9I=";
           };
 
+          duneVersion = "3";
+
           propagatedBuildInputs = [oself.bls12-381];
         };
 

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230324";
+    octez_version = "20230327";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/2724553699da75f0a37bc4066539ab812766c46c"><pre>P2P/Test: Fix a nifty bug</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a9da4eb72409f32bd4dff528327d878d5bc5d8a1"><pre>P2P/Test: Use properly the Lwt monad</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b3ace29b4174f22a04f6436582ccec170794869b"><pre>Merge tezos/tezos!8194: P2P: Solve a flaky test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b362f1e61611686a62e862f7477091b038eee6e1"><pre>EVM/Kernel: move all sources of panics into main</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/283c936e7252e8f1df6ace22fad0490a76ef7dfe"><pre>Merge tezos/tezos!8201: EVM/Kernel: trigger panics only in main</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/98270a9407621d3397faea7c50aaab66244865cb"><pre>Kernel SDK: copy remaining SDK crates from tezos/kernel</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0bff705c081ff4c71b39446a9f47f91683806621"><pre>Kernel SDK: switch installer kernel/client to workspace</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e88c8ca5f8416ff8ab244c4b0015bf29311e1b97"><pre>Kernel SDK: improve doc of tezos_smart_rollup_storage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/573391f9717d39dce03cefd8d6e3cd892237a82a"><pre>Merge tezos/tezos!8182: Kernel SDK: copy remaining SDK crates from tezos/kernel</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a19c9885147bc70817e141ee969cfbbbb732ffab"><pre>Docs: Alcotezt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3e67e4ab853a8647184bf8258b226f51a02c4377"><pre>Merge tezos/tezos!8112: Documentation: Alcotezt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5f357d159da3d69912081356b3e988ad17412bd1"><pre>DAL/GS: remove useless field peer from output type</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c8db4f21fa0ee48eb44b8863a25c7c350bae9cf7"><pre>Merge tezos/tezos!8207: DAL/GS: remove useless field peer from output type</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0bda71dbb08ed62337ed9b89b131fdebc55ab8dc"><pre>Test: test reorg with missing blocks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a9f0a403876f2ff93ce1b4bcc102238f0d447df9"><pre>SCORU/Node: computes predecessors with local information as well</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/db78fc656ced85f4b72e78b4c65db017f2913e9d"><pre>SCORU/Node: pass predecessor around instead of re-retrieving</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fb25dbc60661e0735e0d0c03a970edd97d3d7f38"><pre>SCORU/Node: fallback on recursive head processing</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9bea12d81ab0b9d12855f6c0feb6372a02e4e116"><pre>Injector: recover on non computable reorg</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1ed15baae9e96e3c4b506bea23c312da4030bb30"><pre>SCORU/Node: backport !7751 to Mumbai</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/43a2bfe8ec26a5c0a1188cea0137be8d061f4820"><pre>Merge tezos/tezos!7751: SCORU/Node: use local information to compute reorganizations</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4aff272d620a903f5d0a4c3bbeab233506125cf1"><pre>Baker: add level and round to (pre)endorsement events</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f22790728eed89a0992724cba7f04e89531d0e0f"><pre>Tezt/protocol_migration: shorten logged baker events</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/843cd033f1130eeb03c48783f5668efdecac071d"><pre>Merge tezos/tezos!8065: Baker & tezt: log (pre)endorsement event level and round, and shorten baker logs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9ab818c0eafa1538f3ca4de5b58ad506a67cf6e2"><pre>Accuser: make the accuser wait for the protocol to start</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6df7c4da9bb923fc0abee4650c4d0b0252d0ed5d"><pre>Accuser: factorize protocol waiter calls</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/859c5887d9e0b9eb95fe402ceca7e16280d8902d"><pre>tezt/tests: change accuser\'s readiness condition</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/aaa2e990419993890dbb169f9f8e471cb1f8513e"><pre>Changelog: add accuser entry</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/687c44979b9dba968236447a5d00112c83c13129"><pre>Merge tezos/tezos!8099: Fix early starting accuser</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b2c6d1d4a94aecb596751d3f1d4ad62a3b66cad2"><pre>Snoop: fix out_names in tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8d5fa0e68450aba76d0906562a46c5c73dfa834f"><pre>Merge tezos/tezos!8179: Snoop: fix out_names in tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e0b486077cafc45fd3d63f9f1342a957fb6938bb"><pre>Proto/Michelson: Refactor elaboration of lists</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2b6d4fe3f554ee3174a275a5a432a0990628797b"><pre>Proto/Migration: Refactor patching of scripts</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/da1b22f2c9aaee9a7c7275cd81a62afc5de89db8"><pre>Proto/Sapling: Refactor iterations</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c04e16ffb8cd9f7ea1bded2ddbf28e6a14d47088"><pre>Environment: remove fold_right and its variants</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0a528bd1800628af6027b93ce89c95799e2f9d00"><pre>Merge tezos/tezos!8143: Proto: remove fold_right from environment</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/3b517d3669d7b7515b7de62a81197862d35b3d22...0a528bd1800628af6027b93ce89c95799e2f9d00