### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1679865578,
-        "narHash": "sha256-sYQmxxqIYL3QFsRYjW0AufhGur8qWfwoOGPGHRJZlGc=",
+        "lastModified": 1679944645,
+        "narHash": "sha256-e5Qyoe11UZjVfgRfwNoSU57ZeKuEmjYb77B9IVW7L/M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4361baa782dc3d3b35fd455a1adc370681d9187c",
+        "rev": "4bb072f0a8b267613c127684e099a70e1f6ff106",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1679948742,
-        "narHash": "sha256-wZp2FycFXYhQ5nmftqBi7j0PN4i5y6hKWxgPdOFzcLY=",
+        "lastModified": 1680035393,
+        "narHash": "sha256-+IUZoXFdxtEiqu7ZE9m0gBvZOUak2EqoZ0e6ZHv402Y=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "3c0701b92ffe89127064de11ed87ee61bb1477c4",
+        "rev": "96d2ed818cb66969a70c1918e438dd92abbf7d28",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230328";
+    octez_version = "20230329";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/9f9ef74602a52dbd8d5b3f53f871f307262d7045"><pre>[test_tez_repr.ml]: remove duplicated test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f0e6b3ecadc9ee1663a3620f24da28a36f15d788"><pre>Tests: deduplicate test titles</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/695cfd37658c6e3ba9f054961a80a69bc6b767b8"><pre>[lib_base/test]: combine tests to deduplicate title</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4b97ed7fb00a5ce9652e70ea5881c924ba1b15f9"><pre>Merge tezos/tezos!8227: Deduplicate tests and test titles</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cf9c6fe05988378c09b0d91d2d543fc8858781a1"><pre>EVM/Kernel: depends on tezos SDK</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4c4dc36d9d793fe59c1b2dd87c59ba0bdf792098"><pre>Merge tezos/tezos!8137: EVM/Kernel: depends on tezos SDK</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/13862658b65bceee1dcf20f516375830561e6970"><pre>Benchmark: refactors Dep_graph with better graph types.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3e0b4d3c8469f87f123a5ca09edd66f0fd1d0daf"><pre>Snoop: variables are now overridden only when the solution provides them</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/928df0a47afdeb43f25b2bba5f69d443ae110d64"><pre>Merge tezos/tezos!7887: Benchmark: refactors Dep_graph with a better graph types, with fixing the inference result override</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f828b4c10d80f6db68053a9d93b27bb1f5166b99"><pre>Alcotezt-ux: fix invocation headers in protocol-tests I</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/32d8dd22c2f9ea79ae87fe68f4840f0e5c6e03b5"><pre>Merge tezos/tezos!8122: Alcotezt-ux: fix invocation headers in protocol-tests I</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/520a036f86d018b5d4b5032e28e261c1ad177393"><pre>Alcotezt-ux: fix invocation headers in protocol-tests IV</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/625b039de3ef2d80bde34ba48909cc9562448e5a"><pre>Merge tezos/tezos!8125: Alcotezt-ux: fix invocation headers in protocol-tests IV</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e0a8d5d94df49268a6baaf4c8c3d733cc76ce491"><pre>Alcotezt-ux: fix invocation headers in protocol-tests V</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6a9122240ef8ff2aec084b82e8afab824b3b57b9"><pre>Merge tezos/tezos!8126: Alcotezt-ux: fix invocation headers in protocol-tests V</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/58106b438fcd7c857c786370bf0440a8b5c3032d"><pre>Manifest: treat JS test dependencies the same as for native tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/996454f5711d5426cd49e93446b1cc3b7c111526"><pre>Merge tezos/tezos!8094: Manifest: treat JS test dependencies the same as for native tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b3ebcb4dfb2439d54679259791d213c2971c2c25"><pre>Gossipsub: Check mesh size on graft as done in go implementation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/79059a6af8028585492b03b482f452258be757b8"><pre>Merge tezos/tezos!8240: Gossipsub: Check mesh size on graft as done in go implementation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/25d428746db2ed8a1bf910fa8c2dcb66f11dce3a"><pre>Storage: improve snapshot import animation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0f746298bf29a66171ab31a1960879e1010f0ebe"><pre>Context/disk: add event for context init</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b408fb7a06322f0afad7286ce49fddf37cb85cbc"><pre>Merge tezos/tezos!8191: Improve storage ux</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7fee278e1b3b3bc7122f2e9417c8ca927004849d"><pre>External_validation: proper initialization request</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e0d718a0e51ad48a84bdcf027820eec8866aa173"><pre>Tezt: add external validator test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e9fe3e30369a1af8150081da59aed80e11058271"><pre>Validation: add cloexec flag when creating validator\'s socket</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0cc1af49220dcc90789a11a8b2f6f6d23513d5aa"><pre>Merge tezos/tezos!8039: Proper external validator initialization</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cb5139e5114b184d7ecd64ec0da69eec399b46bb"><pre>Devtools/get contracts: expand global constants</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/38e1fbba422cdcdafef713728790e826f2e1380f"><pre>Merge tezos/tezos!8196: Devtools/get contracts: expand global constants</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cf80f6fe241703452fbe6b219b6d7ea5d2071d1e"><pre>EVM/Tezt: commit input test file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/824cc9f7c849eddc05e6723f53b371774c634f9e"><pre>Merge tezos/tezos!8235: EVM/Tezt: commit input test file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9e58071e965f252c8fdd1bfc3c58252156cb8734"><pre>Gossipsub/Test: Port tests for graft/prune</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4595aa2908db05f1586f968d67a335b90f933916"><pre>Gossipsub/Test: Port tests for heartbeat mesh addition/subtraction</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/784a5ebb6ae520600269d88f3a5e5c50520ac6fc"><pre>Merge tezos/tezos!8226: Gossipsub/Test: Port tests graft/prune and mesh addition/subtraction in heartbeat</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6f25fecdeb2b50c87c46633061bfccbe779de0d9"><pre>Proto/Apply: remove dead error Zero_frozen_deposits (moved to Validate_errors)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/23a8b0773cde01410682cface5dcf9f89c9b3c11"><pre>Proto/Delegate_cycles: fix typo</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4c68bde672b9db403c76249a776f5038272ae118"><pre>Proto/Stake_storage: optimize remove_stake</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/487c9e49f9139fedb240ba4d033ed41050c3e62d"><pre>Proto/Stake_storage: one less negation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b8f74afacb76f9436208ff01027aa8f370747412"><pre>Proto/Stake_storage: optimize add_stake</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bfdcaf31459b8a3ee323b18ddfe80dd3fedf5c02"><pre>Proto/Delegate_sampler: max_mutez already exists</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ee3f2aadfb8ebc76f1f2d8ba16ef06712170fa84"><pre>Proto/Delegate_sampler: get frozen_deposits_percentage once</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dfb1afec2dff328a2e90d113d612f1500f69d71b"><pre>Proto/Delegate_sampler: compute overflow_bound once</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/284d186b98b61eecea6110b7498a7736d2f25ffe"><pre>Proto/Delegate_cycles: optimize max_frozen_deposits_and_delegates_to_remove</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/df3d1f7f3371db60808fced8ad31eca3e777cc7a"><pre>Proto/Stake_storage: use cache in find_selected_distribution</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/96d2ed818cb66969a70c1918e438dd92abbf7d28"><pre>Merge tezos/tezos!8023: Proto: optimizations around Delegates and Stake</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/3c0701b92ffe89127064de11ed87ee61bb1477c4...96d2ed818cb66969a70c1918e438dd92abbf7d28