### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1679737941,
-        "narHash": "sha256-srSD9CwsVPnUMsIZ7Kt/UegkKUEBcTyU1Rev7mO45S0=",
+        "lastModified": 1680392223,
+        "narHash": "sha256-n3g7QFr85lDODKt250rkZj2IFS3i4/8HBU2yKHO3tqw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3502ee99d6dade045bdeaf7b0cd8ec703484c25c",
+        "rev": "dcc36e45d054d7bb554c9cdab69093debd91a0b5",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1678375444,
-        "narHash": "sha256-XIgHfGvjFvZQ8hrkfocanCDxMefc/77rXeHvYdzBMc8=",
+        "lastModified": 1680213900,
+        "narHash": "sha256-cIDr5WZIj3EkKyCgj/6j3HBH4Jj1W296z7HTcWj1aMA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "130fa0baaa2b93ec45523fdcde942f6844ee9f6e",
+        "rev": "e3652e0735fbec227f342712f180f4f21f0594f2",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1679944645,
-        "narHash": "sha256-e5Qyoe11UZjVfgRfwNoSU57ZeKuEmjYb77B9IVW7L/M=",
+        "lastModified": 1680213900,
+        "narHash": "sha256-cIDr5WZIj3EkKyCgj/6j3HBH4Jj1W296z7HTcWj1aMA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bb072f0a8b267613c127684e099a70e1f6ff106",
+        "rev": "e3652e0735fbec227f342712f180f4f21f0594f2",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1678976941,
-        "narHash": "sha256-skNr08frCwN9NO+7I77MjOHHAw+L410/37JknNld+W4=",
+        "lastModified": 1680170909,
+        "narHash": "sha256-FtKU/edv1jFRr/KwUxWTYWXEyj9g8GBrHntC2o8oFI8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "32b1dbedfd77892a6e375737ef04d8efba634e9e",
+        "rev": "29dbe1efaa91c3a415d8b45d62d48325a4748816",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1680035393,
-        "narHash": "sha256-+IUZoXFdxtEiqu7ZE9m0gBvZOUak2EqoZ0e6ZHv402Y=",
+        "lastModified": 1680355461,
+        "narHash": "sha256-qSrstjq7ENefh46znoyThCF8Wp+W+Q9pKFvT789L+vc=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "96d2ed818cb66969a70c1918e438dd92abbf7d28",
+        "rev": "bbd3a25209392d5804e44e632d59ffa922caaca7",
         "type": "gitlab"
       },
       "original": {
@@ -258,11 +258,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679588014,
-        "narHash": "sha256-URkRSunu8HAp2vH2KgLogjAXckiufCDFrBs59g9uiLY=",
+        "lastModified": 1680218481,
+        "narHash": "sha256-VhkSVeKXbZtdaT41Kn3QuFE7OnXHM4UbMlqBez+tRL0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "af75d6efe437858f9ca5535e622cfbedad1ba717",
+        "rev": "a082287718105c284475df18b882a76312dea0d0",
         "type": "github"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230329";
+    octez_version = "20230403";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/450af101cda944ae16e43083d9ae7364038bfe52"><pre>DAL/GS: fix typos in docstrings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bb3c14cdf2bbbf3c2449713f359a0de78070ed20"><pre>DAL/GS: extend the worker to dynamically join/leave topics</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0c4528a2d44c4106336cc382856ac024f73766e9"><pre>Merge tezos/tezos!8152: DAL/GS: join topics given at startup</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5ddb822b685540c4f076370f9fe1ec0cf0f5f62c"><pre>ZKRU: lazily compute setup</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e79876dcf17b88d684cacabd9f63cfa29c3809b9"><pre>Mumbai/ZKRU: lazily compute the setup</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/12c0ee793e9a8370c1d0b59c1c27da8484546575"><pre>Lima/ZKRU: lazily compute the setup</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5ad69af35c18d5a8a1d4d526bfa4094ea5ef1743"><pre>DAL/Test: Initialisation of the DAL is lazy</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ebc8df4dd4e88314bcc2fe53cfb75e3732e7d77c"><pre>Alpha/Test: Initialisation of the cryptobox is lazy</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8360a57ec0e4c1b9c2c616eae7140bb78a379b04"><pre>Mumbai/Test: Initialisation of the cryptobox is lazy</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c66bc6f772ce107584b643a6ad8c7eb14fa74bd7"><pre>Merge tezos/tezos!8237: Tezt is faster to initialize</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b9838ae6ee9f528dad2213479872da85c0b97ab0"><pre>alpha/lib_plugin: add attestation_rights rpc and deprecate</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f0c22fb2d233e8b75aafe33769091d4313ea41f1"><pre>tezt/lib_tezos: add attestation_rights rpc</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2249e7298e1dd2941d4f7264cd18795d9bd577df"><pre>tezt/tests: adapt tests with attestation_rights</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d7ac661bae6bac6e366e02582bc46916801c5d88"><pre>tezt/tests: update rpc regression files</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/acde49ec37bb0700876eeb17f7f92b83fdb94b2a"><pre>tezt/manual_tests: fix endorsing_rights naming</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c4f1ec5dceb5af9c859ea863a772c328586c8c88"><pre>changlog: add entry for the new attestation_rights rpc and for the</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d561048aa8d7ec0426d9f6f79c990db010cb1372"><pre>Merge tezos/tezos!8096: alpha: add attestation_rights rpc and depreciate endorsing_rights</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/734fcbe6d99f148097e492db1de4d8b66cd5e900"><pre>Alcotezt-ux: fix invocation headers in protocol-tests II</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3657719d8bd75e6d23d1177a47ad16fbd8a4883c"><pre>Merge tezos/tezos!8123: Alcotezt-ux: fix invocation headers in protocol-tests II</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/41f64233da02207bf77ae99b2385047c9bf7b551"><pre>Scoru: Move Enocdings_util to lib_tree_encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/81081f5d8025924d38c35500d274e76b6642c467"><pre>Scoru: make Lazy_map.origin wrapped_tree explicitly</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8b8129dcf11a974d5967653a137cf6e66ea6b6a5"><pre>Merge tezos/tezos!8139: Scoru: preparatory steps for in-memory durable replacement</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4aef5a9f6db03f1d4d3a5d1f5680a67fea890e08"><pre>WASM: Modify the API of the durable storage to hash any subtrees</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/82a9d83e32949de2d5bb404a9f442ebf2f19d19c"><pre>Merge tezos/tezos!8072: WASM: Modify the API of the durable storage to hash any subtrees</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/34b174fe6a42ab0023fdd920abef150758677492"><pre>DAL/GS: introduce fail_if/fail_if_not helpers to avoid \'else unit\'</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/70e34c358e2db321791ac7d8cb37eabfaff8c938"><pre>DAL/GS: add more doc in gossipsub_inft</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1bfc60086fbc77524b299e6e843f581e291ed1a7"><pre>DAL/GS: some code refactoring</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ccd044c210687edc4e8f0e63647ce5fb117faca3"><pre>Merge tezos/tezos!8248: DAL/GS: add some doc-strings in gossipsub_intf</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/397849da2389766d3c6387ec8e3016aeb41f0256"><pre>Alcotezt: port [src/lib_bls12_381_polynomial/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6e92f77885674294377e8e5e5be8b265267d5e7a"><pre>Merge tezos/tezos!8223: Alcotezt: port [src/lib_bls12_381_polynomial/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e96eb4ec9f5062f6627809a3080c8c5a1a987e22"><pre>SCORU/Node: fix missing text for error</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/78f9962bf1e6b361899c7711d09d4f2f109c23f6"><pre>SCORU/Node: eval_messages returns the remaining messages</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e6766740552b21f64479f34e296d4cded11190c4"><pre>SCORU/Node: fix returns remaining messages</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a5d804d4f9445fd135ef22fd3db0e64b3f4afee1"><pre>SCORU/Node: eval 0 messages makes the PVM progress until next input</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6081e8fd9ccbcb017b9fbbc2ff4e20acff27448e"><pre>SCORU/Node: reuse computed states in dissection</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/484465eb9e3d1bfdc11d4aa092f4fb3c99231419"><pre>SCORU/Node: Memoized version of Interpreter.state_of_tick</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c47a11c825e1ab872ff9774e78b038001be235d3"><pre>SCORU/Node: small refactor, isolate intermediate evaluation state</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/150d1ff08907f69d7f01581c44db03d70f8c2db6"><pre>SCORU/Node: eval_block_inbox returns a full evaluation result</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d5c9a8e5c0237117761be9df4ab462852201f8e1"><pre>SCORU/Node: Disable intermediate state dissection for loser mode</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ed7a8b0e2ca455361de09cbaf8fe520548f78615"><pre>Tezt: fix timeout event detection of rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b0f346755eea934bc9b2338005a43420a008c386"><pre>SCORU/Node: backport !6948 to mumbai rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5653bf07357ad1e16be4b6b27fdea609cc377bb0"><pre>Merge tezos/tezos!6948: SCORU/Node: more efficient dissection computation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3b027a9d255f519f5d5364efc94b98730f476111"><pre>Snoop: add module_filename in shell_benchmarks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6ece5adf1470b19a08c3d4af6369e4b9123d7b66"><pre>Snoop: add module filename to lib_benchmark_proto</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/67bc2f6222c8c4e2f93cbd4bff2b4bd0171bcef5"><pre>Snoop: add module filename to Benchmark.S in lib_benchmark</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b1df8b0aa1068ee16c1f936b9121e2afbf9c643b"><pre>Snoop: display benchmark filename in the cli</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0d516799248206f6dfa54949db24b16388be1e55"><pre>Snoop: add benchmark filenames to proto/lima</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9c99cbe9892295bece11d7d9295fa248c584ccd0"><pre>Snoop: add benchmark filenames to proto/mumbai</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8866bf3a2212d6491ec2af00d6ca2094f20fb1f7"><pre>Merge tezos/tezos!8067: Snoop: add benchmark filenames when displaying info about benchmark in the CLI</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/81786d147a4b2dd31dc6ec4924f3994abc42181d"><pre>Templates: add EVM template</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/67e84e66534e3178befb94d39bf1059ec0269677"><pre>Merge tezos/tezos!8236: Templates: EVM & Uniswap template</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/74524f5b36f2fb15eb88233c3e37b0cc1bcf8a35"><pre>SDK: fix set_panic_hook path</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/09f2135171145f7f8eee23b51d6ffd40d394d2b6"><pre>Merge tezos/tezos!8261: SDK: fix set_panic_hook path</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4fe4659f0c5a1291b87d0a7c37354bdeb92e4eb6"><pre>Gossipsub: rename Memory_cache to Message_cache</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3c0c851e2b0b9d242893443433b28ba1695ec345"><pre>Gossipsub: complete module Message_cache</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/63ae40cb5a47272a12ff16e7ba2975f86102b867"><pre>Gossipsub: advance the message history sliding window</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5296794a6c41f2fa67bd544d72bf386d30cd8774"><pre>Gossipsub: Add a PBT test for soundness</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bf2cf940b988ec1196b4947df53b27047d361095"><pre>Gossipsub: add a subsignature to AUTOMATON_CONFIG</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a19bbd17fd9557c53d42f199961c4352fb06f1ca"><pre>Merge tezos/tezos!8205: Gossipsub: complete message cache</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/377174e09ad910a0712158a7ab34a2b2c5226f6e"><pre>DAC: hide Dac_node_client.call + expose utils functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/990ed39dca7f07b04f0921bdf2a8206bf0c06aaf"><pre>DAC: hide Dac_node_client.streamed_call</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ac2d8dcf6b9748113e8e81ba65f4f767a6b5c422"><pre>DAC: set convention (http method + path) for RPC helper functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dbaf8d8be973f0ef0f1ebb6c34583b689fe1d07a"><pre>DAC: delete useless call function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/644b211b7e7edc9c3624bc7b8a3e7079d79a4397"><pre>DAC: naming convention for endpoints + reorganize tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/efc2974889e61bf50c765f40840e66fc22f7011e"><pre>DAC: update following rebase</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/21f5223bd244ec30bc3ce74100bb34673fbc65e0"><pre>DAC: fix rpc_services following rebasing</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6c3b7416fc8e83abe16a7ec8e2ba722d99cd25fe"><pre>DAC: use Dac_node_client.put_dac_member_signature</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1a303a032284eaebf4c22ce771c9752d60101321"><pre>Merge tezos/tezos!8001: DAC: rework dac_node_client interface to hide call and streamed_call</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/84e26d383116a6c29b30883bd73a3cb0f0d80f6e"><pre>lib_tree_encoding: port tests to alcotezt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7ff18ad50c29616bf8d83501633d9bf2a6e56f88"><pre>Merge tezos/tezos!8204: lib_tree_encoding: port tests to alcotezt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/10f685212c28f130eebe44cb16ea67a505572524"><pre>EVM: use same fmt as in tezos/kernel</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/122d83a5e0375c09ae8df7c329a4658752b3361e"><pre>EVM: match evm_execution dependencies versions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/77a518f8250e64d875824dbbbb59255f68bd05ba"><pre>EVM: copy [evm_execution] from tezos/kernel</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0b867416faa6ef382150df4082a07cb4505121b4"><pre>Merge tezos/tezos!8244: EVM: copy crate [evm_execution]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6457a56d00fc9a66f14c635e8d2f0b38d7f4bd9a"><pre>lib_version: port tests to alcotezt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/61dcdf2496f91d5f9f4854a1874899989dff40d4"><pre>Merge tezos/tezos!8202: lib_version: port tests to alcotezt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c1c1bc744f02cf5c352e419e36b1fc1657efb9c0"><pre>Gossipsub/Test: Prepare tests for mesh update in heartbeat</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/481f27c1cca0ce8ff4da35499c48306deeeccddc"><pre>Merge tezos/tezos!8266: Gossipsub/Test: Prepare tests for mesh update in heartbeat</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/45730ed1007a7479fb17310c59fc8d2f9328b750"><pre>Proto/VDF-daemon: update VDF daemon events</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/20de43681403bb2cac6386fa836497e7b8401309"><pre>Proto/VDF-daemon: fork VDF computation in separate process</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/31bc1302450ec231900e6d63c5bff5acb53a9f96"><pre>Proto/VDF-daemon: inline setup inside status to avoid mutability</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3097399316ec7aef57588a9157f417f7bac0c752"><pre>Proto/VDF-daemon: helper functions in separate module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/922bd06bfaa1074ebf8f480bb6c9f2495887626f"><pre>Tezt/VDF: test helper functions from lib_delegate</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/14e33757bddb118dfb0ab8f983996e150250afa1"><pre>Merge tezos/tezos!6299: Fork main computation in VDF daemon in separate process</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cba38659326891654992f89a741a989b78a917b4"><pre>Alcotezt: port [src/lib_dac_node/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/04b7f15f87ac8e2087c66af3594bef2a0489b505"><pre>Merge tezos/tezos!8219: Alcotezt: port [src/lib_dac_node/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9f82412f0c829d2219e2e22230607e7a26917792"><pre>Doc/Michelson: redirect operations on contracts to interactive reference.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ea1eae573506316be9786287e866c5889e153336"><pre>Merge tezos/tezos!8247: Doc/Michelson: redirect operations on contracts to interactive reference</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6c57d7cb4a2b49f7e4cc4a4ad687fb6645f0c004"><pre>Proto/Alpha: divide by 4 the proof of work baking difficulty</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d769dc4bb4ab8c7a0ebec65addea711cc0427f84"><pre>Changelog: add pow reduced difficulty entry</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2044b9622ad8bad8e07d1dd708fd9be81f7d48d8"><pre>Merge tezos/tezos!8243: Reduce proof of work baking difficulty</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/95713dffbe0bae16f7b0843478c7944088d6abcc"><pre>EVM/Kernel: remove generic error</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ed9ee669804f9e3bd0997e272f92913118271314"><pre>EVM/Kernel: remove unnecessary map_err</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8484c7d1de786818c17d37034e6b49a9db7158ac"><pre>Merge tezos/tezos!8220: EVM/Kernel: remove generic error</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/783bff9f853df64ebf94b5ed6a33d9af29794671"><pre>Changes: document incompatibility with <= 15.1 binary signers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a1967e257b914fd19c1cd87eb53f65162306bc9f"><pre>Merge tezos/tezos!8245: Changes: document incompatibility with <= 15.1 binary signers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/84d5b23e03d688c803f0ddae553687bb03ee484a"><pre>EVM/Kernel: use panic_handler</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3c8a30fc603e9f027220ab61ca832081f92727b0"><pre>Merge tezos/tezos!8262: EVM/Kernel: use panic_handler</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ea2f7d1e3cf807bf4b7094881477adaa88871d0a"><pre>Gossipsub/Test: Port [test_do_not_graft_within_backoff_period]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/674eb5ba47470e8a8fac1e05cc82bac68f33739c"><pre>Gossipsub/Test: Port [test_unsubscribe_backoff]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/33510b8de859f2c67140a7373b895abd5b6c8861"><pre>Gossipsub/Test: Port [test_accept_only_outbound_peer_grafts...]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eb781b1b97b1868066125f2031ce89a42cd93556"><pre>Gossipsub: Relax the assertions on limit</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/03d4deefec6e0f9471fdbc4c4d5ada34ca86b6ea"><pre>Gossipsub/Test: Port [test_do_not_remove_too_many_outbound_peers]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e9381bdfedacbd3a4cb4f3628592f5bb134f2e66"><pre>Gossipsub/Test: Port [test_add_outbound_peers_if_min_is_not_satisfied]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dbde1af49675be013f6c5cfcddf29aad79004f79"><pre>Merge tezos/tezos!8267: Gossipsub/Test: Port tests for backoff and outbound</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/97b99fa9bd66668cd53597c374f8e7b644e29a53"><pre>Doc/Michelson: redirect operations on big_maps to interactive reference.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ea01a598a01f2009be9bb27682deec2c10a54398"><pre>Merge tezos/tezos!8006: Doc/Michelson: redirect operations on big_maps to interactive reference</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d52a51dbfff186cb2569ef500e889b17d91ee583"><pre>soru/tezt: fix long test parameters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b9a9a40e1793d660782fa8e4f71e0c2ed037ce32"><pre>soru: simplify sc_rollup_forward.tz script</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5d79b42c2fcf8093884b8b2dfeb6c52bf764ceab"><pre>soru/tezt: reuse contract when possible</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3364777821c0690c8732903be49884767c39da3f"><pre>soru/tezt: replace string by constant</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b110de5001c103d8fc9f8abf8344cc72d1f8170e"><pre>tezt: reset regression trace</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d845607a258dd3c7f63dff34424195b7c06cc584"><pre>Merge tezos/tezos!8250: smart rollup test: small rework</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e4f65f52837d743523e4baa571fc34c26eef6b30"><pre>Gossipsub: add check for max IWant requests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b7a6ef22f35d629f32b03f40ccfcd75231e48433"><pre>Gossipsub: fix some typos, uniformize some names</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a7ccc250deb58c2e5df1bde597b41358743f109a"><pre>Merge tezos/tezos!8279: Gossipsub: check number of IWant messages</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d41b42d64949a23994af055d78ec0bd8498323c3"><pre>doc: shift doc to Mumbai</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d2178cce36d8dbc06f632ece9e32ec2cce21ac25"><pre>doc: rename octez/tezos in install-opam*.sh</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9256fca16d23de84eaf71df71f7f82187aab76e6"><pre>Merge tezos/tezos!8215: doc: shift doc to Mumbai</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b7ae8ad68bd38cccbb7a4aecbb34969970135e7f"><pre>Node: Remove limanet network built-in alias</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/550f2ea7bec5598c37a047057c2690b8b5699697"><pre>Changelog: Add entry for limanet alias removal</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eb3003a364dbf6c95d5f931935674e716b3ccc74"><pre>Merge tezos/tezos!8284: Node: Remove limanet network built-in alias</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c4163208d49b01d54dd56ef51ac7310e2703d6fe"><pre>soru: replace storage call add by init at origination</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/db9f94bd61b576619578a91d2c178db323b07b47"><pre>Merge tezos/tezos!8068: soru: replace storage call add by init at origination</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e9f3a54686c7344d89194218c4b156f88b47e769"><pre>tezt: add \`?patch_config\` to Node.run</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/35119344738a57e1afbe5d2b188c33181bb22bdc"><pre>tezt: helper fct for originating contract</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7e75b923e87bde75c51e8e670f783f8367d0130c"><pre>soru/tezt: inbox is robust over migration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/071c5893c20aa80fbf7980ce2a34f732e41629d5"><pre>tezt: add regression trace for new script</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/50d6a9365eebe51f17d33be2b8429d4daa0a4e15"><pre>Merge tezos/tezos!8251: smart rollup: add inbox migration test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b7236dcbaf50d7ebc9018088bb25446167bc6e1f"><pre>soru/tezt: remove regression trace of outbox exec</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9f04c09d5c1d23d3a462048af1527b3bbd837d57"><pre>Merge tezos/tezos!8278: soru/tezt: remove regression trace of outbox exec</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b12d496888850bda8dd019fe118e6b97a7fdf965"><pre>Docs: fix doc of [store_read] and [store_write]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0c64c03f548b0362730027d2a8a8e6b2204a11e1"><pre>Merge tezos/tezos!8290: Docs: fix doc of [store_read] and [store_write]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/61f968a9500a7b39fcb2ad58b96bbe9f2fed2d31"><pre>sdk: core rename fn store_list_get -> store_get_nth_key</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dc32e121811602e8b4790ac343ddd1bacf72cedd"><pre>sdk/runtime: simplify err logic</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/70e8c9c56f7c76705ea9fde35936c5754b6f2ac0"><pre>sdk: runtime get_subkey write path sep first</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b618e963bc6870d5740cc0ac768955f19175b315"><pre>sdk: runtime returns a option path for get subkey</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c9e262f783b62a2e31aca8e83668e919dd40a384"><pre>sdk: use realistic host fct response in test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0e23b37ded9d244620cc1cbae442f83f1740935f"><pre>Merge tezos/tezos!8238: kernel sdk: rename store list get to store get nth key</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0fc62fae581040e2498b40f6f90e773796ed8527"><pre>Gossipsub: Populate [seen_messages] and skip seen messages in publish</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/69be19d3ff7e1c0337be2c49ad3e2b80bd50195c"><pre>Merge tezos/tezos!8287: Gossipsub: Populate [seen_messages] and skip seen messages in publish</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/71f168a7a54a5ba9d59050240c9dffac775cee39"><pre>CODEOWNERS: add @alocascio to the Octez Merge Team</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9c5aaee73f68b02d480d74e831c739e8e75209b9"><pre>Merge tezos/tezos!8296: CODEOWNERS: add @alocascio to the Octez Merge Team</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/79025b098f5251419dd478f5135c979fe85d41fc"><pre>Alcotezt: port [src/lib_benchmark_rewriting/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cb088d8796b12f0073ffdd0e0c129e7b78f4d300"><pre>Tezt: convert to tezt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/727a328c34a7ae74e2db79c44ae9f25e14cc1531"><pre>Merge tezos/tezos!8218: Alcotezt: port [src/lib_benchmark_rewriting/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/57df1716917639484edf5b4fb62c3e6cfdec90b1"><pre>Gossipsub: update mesh in heartbeat</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6c33c1acb4812efb03fb5aebbd0a43ed1ae5c44d"><pre>Gossipsub/Test: enable tests for mesh update in heartbeat</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/84c82d5d4da427be29f894ab47b328803eba15b5"><pre>Gossipsub/Test: enable and fix test on adding outbound peers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a21f80af1f76a557042ef957921af32e2ed503a7"><pre>Gossipsub/Test: add TODO for test scenario</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7b755d11c91e40570dd2ccad96f78e110f9006fe"><pre>Gossip: update invariant and some doc-strings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c698ec173f217a7c64a72f5547810ecbb487cf7e"><pre>Merge tezos/tezos!8268: Gossipsub: update mesh in heartbeat</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cae5858acb77d922e63e1f455501367ba927268d"><pre>Templates: fix kernel::EVM label</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6dc46a27e72428ce419f560bb0421acec6ff20f2"><pre>Merge tezos/tezos!8299: Templates: fix kernel::EVM label</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/38f2779144a55d050b273ace69fb93335eb0cfd8"><pre>SCORU/Node: allow multiple instances of commitment and batcher workers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c391e5f5f56afbadcaecff39ddcd5bd24642c46e"><pre>SCORU/Node: one directory per RPC server instance</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/61af4060eae146e313d821a23e9a3da6cf5bd649"><pre>SCORU/Node: expose internal functions for unit tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b10d6fc8312706a3647181cbf0a2efd4e535e975"><pre>SCORU/Node: retrieve genesis inbox from disk first before RPC</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3624bf516534a3f3cadad0761f91ae054c7250f5"><pre>Injector: events with parameters section</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/44dd8c6198d01b23e06887810d10e74a368218c2"><pre>SCORU/Node: register errors with protocol prefix</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f593334c62a922370bfcd1be5a77a15590cf19df"><pre>SCORU/Node: events with protocol name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5d2e74b64c26588c482e75c8a9d254786e24ca01"><pre>Manifest: add unit test file for rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/784e648d2b77afc95ad0ba20eec8ac2d9d1adf90"><pre>Test: helpers for smart rollup node unit tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0923b4185beae31e1dcc38df2b76e1d62879a4ee"><pre>Test: canary tests for the helper functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/80dab4406dfab8561bfe908527398893d8da4b0e"><pre>Manifest: enable rollup node tests for Mumbai</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d689412d820b16c7f1408b548e74a53d1c3f0700"><pre>SCORU/Node/Tests: backport !7854 to mumbai rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/26d77d70e8389020ad4375fd88a285196741b832"><pre>Merge tezos/tezos!7854: SCORU/Node: unit tests infrastructure/helpers for the rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6cf6f2b236c51eff8050a9a3850a8b268bfd0884"><pre>Dac: get missing page rpc for observer</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1120721937c0be95f1114207febf5b1f212a0b4d"><pre>Merge tezos/tezos!8066: Dac: get missing page rpc for observer</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/38b2933277f8037656e61142beb33a980f4cf14e"><pre>SCORU/Node: rename module to avoid duplication for merlin</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8781b82f1e36cf7b6410936f8e85cb59eaf44e8e"><pre>Merge tezos/tezos!8256: SCORU/Node: rename module to avoid duplication for merlin</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5ae9303aa64393e73c90f89af5d31bcd4e991f5a"><pre>Test/Tezt: remove regressions for dissections in parallel games</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3d010346e9694c8cee21225685375a86435cb6c1"><pre>Merge tezos/tezos!8308: Test/Tezt: remove regressions for dissections in parallel games</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c181dab9616cf2c191d2c3f72f176ad16262d89f"><pre>opam: update tezos/opam-repository</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/89b7e082e7276f3dd13d689a1052eb0ae2225342"><pre>Manifest: bump up bls12-381 to 6.1.0</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/799b1f8ff126de98438e92c5b936a8592fd2700e"><pre>package-lock.json: update with latest bls12-381 version constraint</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fbf1e918297ee86271adc201b6a6a0fb79464c3c"><pre>Lib_bls12_381_hash: move from cryptography/ocaml-bls12-381-hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/455a3b5ec0baa3a5dde176483a56bba70c422bb9"><pre>Lib_mec: import from cryptography/ocaml-ec</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0b26bc7c203455b960c40c090b4589c41166736e"><pre>Lib_polynomial: import from cryptography/ocaml-polynomial</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d4c1cc9c240b006d9cab1ac5b14fb1b6e479061b"><pre>Lib_bls12_381_signature: import from ocaml-bls12-381-signature</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7be6b449b7f646354a4ed729409b25dcfe04ff70"><pre>Lib_bls12_381_polynomial: drop \`internal\` from names and bindings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e38de3335d91b641278466d139977311ae25dd79"><pre>Lib_srs_extraction: import from aplonk/srs-extraction</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/afcf2e2d810dbcbc1ca76025274083d2b6fe163d"><pre>Lib_plompiler: import from privacy-team/plompiler</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/82641c42ab1f9d4c4c4425b59da423efccf0f8a6"><pre>Lib_plonk: import from privacy-team/cryptography</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/49ece782dbe138de2612f775f053196c0f3ca0da"><pre>octez-plonk.aggregation: import from privacy-team/cryptography</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6df6da0f2ef8d5b33109de71b379497bd124e9a3"><pre>octez-aplonk: import from privacy-team/cryptography</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6a27bcdbf2173aa10f3bee7c5a80a6269601390b"><pre>Protocol environment: open plonk</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5a85f0125fe8f1aed59c35386ae04bef93a07f97"><pre>Protocol environment: change to use new interface of Plonk</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a616b9a8b1f02980020dd1c6384f3cdbdac50997"><pre>Proto alpha: change to use new interface of Plonk</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e057fd8719a90ad16a9cba2d62f26aac3b4f1463"><pre>Lib_plonk_distribution: import from privacy-team/distributed_plonk</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5266bbcaa78a7c09f28b822b5338497d540a80e3"><pre>octez-plonk.plonk-test: import from nomadic-labs/cryptography</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c66986f0d13ca2c6a98ab8b05f08fc2636bb0381"><pre>octez-plonk test main: import from nomadic-labs/cryptography</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3d543c5ad676e8ab7b4823e2360ab70750cb14a1"><pre>octez_plonk_test_helpers_bench: import from privacy-team/cryptography</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eed4c13dc7a04883f9d96c82ef4f7adacd6abdfc"><pre>lib_plonk test_plompiler: add afl</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c1ea0fe4014a772503445b250f3cb480c0f2b60b"><pre>lib_plonk test_plompiler: add main.exe</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/46c1fb711184cd9d1046fdfe9a1b85fbefb2d214"><pre>lib_aplonk test main/bench: import from privacy-team</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2a0b2895d20a47473cda0047e1296af039327f58"><pre>lib_distributed_internal: import from privacy-team/cryptography fork</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3a528c48b563155423e5d09d80660bbd9418d43d"><pre>lib_plonk_communication: import from privacy-team/aplonk</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4bcc4341f06057bc363300672e0158aa6dcacbed"><pre>lib_distributed_plonk: import from privacy-team/cryptography</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/979ca34d5c118c6f0b4c1886e1cc6b3abbac84ff"><pre>lib_distributed_plonk test: import from privacy-team/cryptography</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9bab8e1d07e2ea59b165feb384604562a6f9f5c7"><pre>lib_distributed_plonk test main: import from privacy-team/cryptography</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/353a504de761ce46fa6be1c52c50b3176980e413"><pre>lib_distributed_plonk worker_runner: import from privacy-team/cryptography</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ca383f009a5a9aa4172b66572eb3ad77ff23469f"><pre>lib_epoxy_tx: import from privacy-team/cryptography</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b2ae75ead43f4ffa9cd9a8ce1ab8b71f97c9b18b"><pre>Proto L: change to use new interface of Plonk</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6bdc0e16d94e16464b3966e057d8e5e2a7a141e4"><pre>Proto M: change to use new interface of Plonk</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c1fe4f58e3cd4e064a849cb5f0c68daf16661ac3"><pre>Manifest: deactivate z3 tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e68de62e3cfa4a1e5de2cc231ffab35ead27bae6"><pre>Alcotezt: port lib_polynomial</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6ef1ac553e8051a4cbfe7a430dd52fa7d96cf5fa"><pre>Merge tezos/tezos!7932: Move cryptography packages</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a36ff9e62e8dc2115fc46142916d5ba8f3c11093"><pre>Gossipsub: Update outdated issue 5007</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/73ad160a58df3ecdb3eac5963e7aa54a05ee4965"><pre>Gossipsub: Update outdated issue 4980</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6576c78b894d117454faca5389f586f368dc4c14"><pre>Gossipsub: The worker will have to send to direct peers in any case</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9719a8b5be78a68b09924619ecca2a1a85859d2b"><pre>Gossipsub: Add a reference to !5305</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bbd3a25209392d5804e44e632d59ffa922caaca7"><pre>Merge tezos/tezos!8289: Gossipsub: Update some issues and solve one.</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/96d2ed818cb66969a70c1918e438dd92abbf7d28...bbd3a25209392d5804e44e632d59ffa922caaca7