### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1680487167,
-        "narHash": "sha256-9FNIqrxDZgSliGGN2XJJSvcDYmQbgOANaZA4UWnTdg4=",
+        "lastModified": 1680669251,
+        "narHash": "sha256-AVNE+0u4HlI3v96KCXE9risH7NKqj0QDLLfSckYXIbA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "53dad94e874c9586e71decf82d972dfb640ef044",
+        "rev": "9c8ff8b426a8b07b9e0a131ac3218740dc85ba1e",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1680676024,
-        "narHash": "sha256-3ah6JlWoqDAry1bhw3QVF6o63uHa5pZL1D5ng0rV9Qo=",
+        "lastModified": 1680757863,
+        "narHash": "sha256-NamrSZw02eSsk4fYwzIhkuRxECPoNCgPjOKY9VVJha4=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "7695d76be253da9d81de6555f998c7981083d3d3",
+        "rev": "3cac2aff599c654f791b0315fc1391c84c30aeb5",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230405";
+    octez_version = "20230406";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/2fac0f3edc70eb6d6a641d678693a54c969fdf27"><pre>CI: Isolate lib_store’s Unix tests in a dedicated job</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/73d41b8f01066d1c1746e6135e01abc99a5204b4"><pre>Merge tezos/tezos!8328: CI: Isolate lib_store’s Unix tests in a dedicated job</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/270a8c98c2a688f916961fd7310cb33c8d69c711"><pre>Kernel SDK: add ticket hash encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/935277f3faf0cd0dca42c211a29d7fbbee641593"><pre>Merge tezos/tezos!8249: Kernel SDK: add ticket hash encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ae4c0217b7ab39a82ebf35ae8b5197d247641ff8"><pre>DAC: coordinator must know root_hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d04bc81c30b180a319214fe201feaa023a031b91"><pre>DAC: use Page_store.Filesystem.mem + get rid of useless plugin parameter</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/18a3cb392c8daff2451b146d4fcefd07f68b8122"><pre>DAC: return 404 if unknown root hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1178b2d10024a2ee64121e60ffa6552ab0dbdd5d"><pre>Merge tezos/tezos!8233: DAC: coordinator must know root_hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4488b4c7836e6c6a3617ce405095319d1c8774bb"><pre>Test: fix test broken by configuration change of rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ffe6d9879d40480bc55202d207364aa11a417579"><pre>Merge tezos/tezos!8360: Test: fix test broken by configuration change of rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/204c3500fbeec977842229230c0792e4e60b836e"><pre>SCORU/Node/017: use minimal indexing strategy for irmin context</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6b9919bfbc4c317c426f9124e762e118114222f5"><pre>Merge tezos/tezos!8351: SCORU/Node: backport !8252 to Nairobi rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b4b422d7aba5b8e397113ba13ed70ba509d9f3b7"><pre>Scripts: fix the invocation headers replace proto_alpha with proto_new_version</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6d30a8f4110bc06b6f1f2d4657a91a300683c953"><pre>Merge tezos/tezos!8161: Scripts: fix the invocation headers replace proto_alpha with proto_new_version</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3a874b72e8330f1133ed9dfaae65bac0867b4956"><pre>Shell: fix inconsistent hash on reorg in singleprocess mode</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/58b16eebc016d7dd466f47c14b5863e8493ccac9"><pre>Test: add a singleprocess branch reorg test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a8adf4da71c1b3ee97174d8ddb9def89af462adf"><pre>Merge tezos/tezos!8320: Fix singleprocess inconsistent cache</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/70d006629c44e30b6f83d4fc8fa6ef1a929be591"><pre>Gossipsub: Fix bugs in handle_ihave related to iwant count</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5218296a4b0680628cc1a07a0377d46c59ac0781"><pre>Gossipsub/Test: Port tests related to IHave</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/218c30ebd996bbfc60c670e7ffcf67ea8c202f82"><pre>Merge tezos/tezos!8337: Gossipsub/Test: Port tests for IHave</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/62044e2179959e2ab57fabbe81644d0a2d68cb14"><pre>Dac/Node: support all operating modes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0d3b1c329bcb05cc13bbac3419bc2cc6c5eb7f8c"><pre>Dac/Node: move handlers to own module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/800b07e83dbd68e195550ad3672bb8969c604840"><pre>Dac/Node: Remove DAC_manager module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/10be67fbb806d79e5e64592982c37119775dfb7c"><pre>Dac/Node: fix typo in committee member configuration command</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0305f30cbb6a6b80b7a5f546408296c9a4289e90"><pre>Dac/Node: fix coordinator port parameter in committee member encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e5c35aed0eeda40a54bf72f6ec3bef89a0821c82"><pre>Dac/Tezt: disable preimage test for legacy mode</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d151cc5bd9ccf0255e2460f4e55951abae1656bd"><pre>Dac/Tezt: Helpers for setting dac nodes in tezts</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4b4eafbe68705f2dff4f5271259bd1287cc5ded8"><pre>Dac/Tezt: re-enable test using coordinator</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/06b26dced2dcbb5978a2fb5cefc70f5175edf084"><pre>Dac/Tezt: rename scenario_with_all_nodes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ee0673dcafc80908eb2929179bbef21170d85397"><pre>Dac/Tezt: improve overall structure of code</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f59235942ce1ecfe414c7ad95bad9ca1aa8eefd5"><pre>Dac/Tezt: committee members and observers download all pages</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8af1f95b2770bc686706105967f01be6f0af5e77"><pre>Merge tezos/tezos!7972: DAC: Implement Operating modes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/243393a8dec8df605afa432b5560f4e35a8f26ff"><pre>Kernel SDK: correctly enable panic hook</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/717ec46db4ddc3b3d82f4a7d352fb13acf648383"><pre>Merge tezos/tezos!8354: Kernel SDK: correctly enable panic hook</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7f3b2e811831a618dbe09c2c89681c1e2ddaaa89"><pre>Backport !8099 - Fix early starting accuser</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/642f2af049cf76c9157452807e6d48733f2c115e"><pre>Tezt: Fix leftovers from Nairobi initial snapshot</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3cac2aff599c654f791b0315fc1391c84c30aeb5"><pre>Merge tezos/tezos!8347: Tezt: Fix some leftovers from the initial Nairobi snapshot</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/7695d76be253da9d81de6555f998c7981083d3d3...3cac2aff599c654f791b0315fc1391c84c30aeb5