### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1680599552,
-        "narHash": "sha256-rQQJFGvWQ3Sr+m/r5KGIFN0iVaVKr6u9uraCz6jSKj4=",
+        "lastModified": 1680796877,
+        "narHash": "sha256-2Cep1iSIM1H+BJYp792YAPWedTAnmrYTIVPhnPPDaCY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3342d7c51119030490fdcd07351b53b10806891c",
+        "rev": "d8480d44ffd2e1b5440a3cf74ce6fb299557e9a0",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1680757863,
-        "narHash": "sha256-NamrSZw02eSsk4fYwzIhkuRxECPoNCgPjOKY9VVJha4=",
+        "lastModified": 1680834157,
+        "narHash": "sha256-d5CCC639vmDkSEkvolVLXLaLZN8D4P1FdMn+JujAVQo=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "3cac2aff599c654f791b0315fc1391c84c30aeb5",
+        "rev": "4154678c54f34c7565c68fce21b6e32ca8d20ce5",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230406";
+    octez_version = "20230407";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/97f814cf9a7f47fb6a5c462e662f1c6e25997947"><pre>Bin_node/replay: restore operation_metadata_size_limit arg</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c86cb8d04dc9e4791a208c082448774fb27cd375"><pre>Bin_node/replay: fix data-dir arg override</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/43b5938a0939007329ed1127b1e18f345dbf9bc7"><pre>Node/Replay: reworked operation receipt inconsistency detection</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0cc7be595b6e34f8b32fcc7d2bbe21f40591844d"><pre>Merge tezos/tezos!8335: Improve replay command</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c4de7522b8849c7bd7b0cdbd244188f4f2b89025"><pre>soru/client: add manual to client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4e6992adc4446ea7109c55b5c3d7f85e3a36a5b4"><pre>soru/client: backport client manual</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/239c71f6ef610dc243e9b326e0b149c4cbd70995"><pre>Merge tezos/tezos!8336: smart rollup: add manual to client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cbfe8f749904be88c1c2e9b8e3abe0c279a86e5c"><pre>Shell/Chain_validator: The disconnection is asynchronous</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9643180a3070bef69c070568baf6be049070653e"><pre>Merge tezos/tezos!8313: Shell/Chain_validator: The disconnection is asynchronous</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6c751c46e5680ba43beedbfb5c7c97daa9bca310"><pre>Tezt: [Alcotezt(_lwt).run] now takes a [~__FILE__] arg</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/59bcb3949aa6cf3c2c16f3829249a19a0a732b76"><pre>test_hash_queue_lwt.ml: disambiguate test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d48cd04b598c91ebb738de4f4a9a5f697dd565dc"><pre>Alcotezts: pass [~__FILE__] everywhere</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/13a6b7bdd62439092045a321d8afd03cd23b376d"><pre>Merge tezos/tezos!7965: Alcotezt-UX: register Alcotests with [__FILE__]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f1b742f1198ecf8c7b24f5eea4c2f57530794b83"><pre>Gossipsub: add doPX parameter</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/053a50f5ca891d835233d6cfe83a5fb4b24af61a"><pre>Gossipsub: add peers_to_px parameter</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bf73f188e9e94138547a26f8b93cb58a0b20c342"><pre>Gossipsub: expose function to select peers for PX</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9dfbabc05ce934332771c60870fa8dbd367e5870"><pre>Merge tezos/tezos!8318: Gossipsub: select px peers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e28fbd3578e39e95019e8fb2f4c4e0782d511df3"><pre>Manifest: upgrade to irmin.3.6.1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/78d54eaf5ffb2649cd4d1c7e1c8a77094750fa89"><pre>Changelog: upgrade to irmin.3.6.1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d37e4cd95aec69c3cb9bb540e2261d70254a426e"><pre>Build: update dependencies</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e514e0c57556afa3124e14de06b5ad3a0123b0cc"><pre>Merge tezos/tezos!8063: Upgrade to irmin.3.6.1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ab9550622413344aa59633eb523abc0173ae04c3"><pre>Backport !8175 - baker: use only consensus operation with minimal slot</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c001658c08c6d1db60bdd0795ed9c1dee2f3f363"><pre>Backport !8065 - Baker & tezt: log (pre)endorsement event level and...</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e30fa3fcbae842bdcffd5111c4cfa54880e53623"><pre>Merge tezos/tezos!8348: Baker: backport changes from alpha to N</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c3bca084da88133104ab2d943481f21cf450eccb"><pre>tezos-base: remove hack for ptime</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8a3648774c6bee4d018276bca55077961285a7fa"><pre>Merge tezos/tezos!8332: tezos-base: remove hack for ptime</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/beb2a36f9f21714eb62bef1625702b09ff6c4342"><pre>Nairobi: Backport !8129</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fb1b7037f55782277d0e53c7bc72843e5877b532"><pre>Merge tezos/tezos!8368: Nairobi: Backport !8129</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/55b33ddef377a95a140a780797af6a2d57be6ecb"><pre>Alcotezt-UX: fix invocation headers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cffa9b7d9a80d2bd6d9db09b97807bf5d168e31f"><pre>Merge tezos/tezos!8271: Alcotezt-UX: fix invocation headers in [lib_p2p] and [lib_tree_encoding]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d447fcf96fc8985f7e9f0b621d686cff8d889411"><pre>doc: allow link redirect on reddit channel</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fa33dc751da97a917c82e156bf76e89a7c46f3f4"><pre>adding protocols KLMN </pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1952d92581780ac0709242c102f999f6789e30c6"><pre>docs/history_modes: replace [experimental-rolling] with [rolling]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/efc158418e821eed0d5feecb1613a7f6f17a4d40"><pre>docs/storage.rst: fix accidental single backticks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/460dfcf4db0cb59b0bebadb13ce039f7d0f0cf9c"><pre>doc: explain what stake is used for the voting power</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c2ab473704296cb28c85b36f85aded24ce9363c1"><pre>doc: fix typos in glossary/voting listings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a1b6607cbe3817e32cfd8cbbb656f65f98817229"><pre>Merge tezos/tezos!8153: doc: Typo train</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/aeae9824ed0a975a372bf6c290d66fa3c215fbd3"><pre>SCORU: Use DAC client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/efeb3ce450431e077d1313281d2431dee7c6a061"><pre>Merge tezos/tezos!8230: SCORU Node: Use DAC observer client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8fe1f88078ed8587f122ea2e6b0172e5c9289b6c"><pre>Nairobi: Backport !8227</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/331a3f28a63356e6ed2f94e6fd0cb8adf9433255"><pre>Merge tezos/tezos!8384: Nairobi: Backport !8227</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1a08c5b116d4ba3f35b20568858052eac9415c52"><pre>Tezt/proto_migration: stop logging all baker events, instead log block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3e2fd5307968022bd1284859ef922547e4804dc0"><pre>Tezt/proto_migration: set expected connection count to avoid</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/01c90b322f81002d63fb7c77ac8102e456009567"><pre>Tezt/proto_migration: revamp baker forked test with event waiters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d18cffd5d46bf2466ad988adf66b96d21642b3da"><pre>Tezt/proto_migration: do not call RPC again to check whether the block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/44ced34c9ab8aadac4daa08d88aedcc513398a4d"><pre>Tezt/proto_migration: fix disconnect</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1081ea244643e2d098396738f57e2df04ad0a3b2"><pre>Merge tezos/tezos!8115: Tezt/protocol_migration: improve baker forked migration test with event waiters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d590a4c6864e376c96dcac4bbfa0795c8b847deb"><pre>Snoop: move lib_benchmark_proto/sc_rollup to new registration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/42a4ad59dc1b04b459c47b7ad329befc3462efd1"><pre>Merge tezos/tezos!8263: Snoop: move lib_benchmark_proto/sc_rollup to new registration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e4e88bd408ef9d2431e900aba1b069979b23e404"><pre>Snoop: move lib_benchmark_proto/global_constants to new registration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4154678c54f34c7565c68fce21b6e32ca8d20ce5"><pre>Merge tezos/tezos!8311: Snoop: move lib_benchmark_proto/global_constants to new registration</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/3cac2aff599c654f791b0315fc1391c84c30aeb5...4154678c54f34c7565c68fce21b6e32ca8d20ce5