### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1680669251,
-        "narHash": "sha256-AVNE+0u4HlI3v96KCXE9risH7NKqj0QDLLfSckYXIbA=",
+        "lastModified": 1681126633,
+        "narHash": "sha256-evQ3Ct/yJDSHej16Hiq+JfxRjgm9FXu/2LBxsyorGdE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9c8ff8b426a8b07b9e0a131ac3218740dc85ba1e",
+        "rev": "db24d86dd8a4769c50d6b7295e81aa280cd93f35",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1680599552,
-        "narHash": "sha256-rQQJFGvWQ3Sr+m/r5KGIFN0iVaVKr6u9uraCz6jSKj4=",
+        "lastModified": 1681227715,
+        "narHash": "sha256-kQZOoTa177VF5uk1JK7bA9ZTU5g6d5IuDp/6YdxUWao=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3342d7c51119030490fdcd07351b53b10806891c",
+        "rev": "c77e64a5adab96866ea97449a5a7a327d4629828",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1680757863,
-        "narHash": "sha256-NamrSZw02eSsk4fYwzIhkuRxECPoNCgPjOKY9VVJha4=",
+        "lastModified": 1681248993,
+        "narHash": "sha256-dv2iU0DLTsJOonhuVkHF+q64e7ZhFbYwsyQAtYV9pi8=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "3cac2aff599c654f791b0315fc1391c84c30aeb5",
+        "rev": "bc08411a8a1301056aef8f062099952490debe5d",
         "type": "gitlab"
       },
       "original": {
@@ -258,11 +258,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1680542917,
-        "narHash": "sha256-lwqpGONfUhyPgNJ3vtFjB1+mEEWDqgsU7pDXsoCjdP4=",
+        "lastModified": 1681115235,
+        "narHash": "sha256-VCETW6vOzNlByc0A5gTJoFE9L/ikP91rX6XynBUgIno=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "08850c9808fd5e1891cad51f38e92226c7e8f8bd",
+        "rev": "f3dd071be31528261034022020fc7e4c010f7179",
         "type": "github"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230406";
+    octez_version = "20230412";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/97f814cf9a7f47fb6a5c462e662f1c6e25997947"><pre>Bin_node/replay: restore operation_metadata_size_limit arg</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c86cb8d04dc9e4791a208c082448774fb27cd375"><pre>Bin_node/replay: fix data-dir arg override</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/43b5938a0939007329ed1127b1e18f345dbf9bc7"><pre>Node/Replay: reworked operation receipt inconsistency detection</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0cc7be595b6e34f8b32fcc7d2bbe21f40591844d"><pre>Merge tezos/tezos!8335: Improve replay command</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c4de7522b8849c7bd7b0cdbd244188f4f2b89025"><pre>soru/client: add manual to client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4e6992adc4446ea7109c55b5c3d7f85e3a36a5b4"><pre>soru/client: backport client manual</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/239c71f6ef610dc243e9b326e0b149c4cbd70995"><pre>Merge tezos/tezos!8336: smart rollup: add manual to client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cbfe8f749904be88c1c2e9b8e3abe0c279a86e5c"><pre>Shell/Chain_validator: The disconnection is asynchronous</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9643180a3070bef69c070568baf6be049070653e"><pre>Merge tezos/tezos!8313: Shell/Chain_validator: The disconnection is asynchronous</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6c751c46e5680ba43beedbfb5c7c97daa9bca310"><pre>Tezt: [Alcotezt(_lwt).run] now takes a [~__FILE__] arg</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/59bcb3949aa6cf3c2c16f3829249a19a0a732b76"><pre>test_hash_queue_lwt.ml: disambiguate test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d48cd04b598c91ebb738de4f4a9a5f697dd565dc"><pre>Alcotezts: pass [~__FILE__] everywhere</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/13a6b7bdd62439092045a321d8afd03cd23b376d"><pre>Merge tezos/tezos!7965: Alcotezt-UX: register Alcotests with [__FILE__]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f1b742f1198ecf8c7b24f5eea4c2f57530794b83"><pre>Gossipsub: add doPX parameter</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/053a50f5ca891d835233d6cfe83a5fb4b24af61a"><pre>Gossipsub: add peers_to_px parameter</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bf73f188e9e94138547a26f8b93cb58a0b20c342"><pre>Gossipsub: expose function to select peers for PX</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9dfbabc05ce934332771c60870fa8dbd367e5870"><pre>Merge tezos/tezos!8318: Gossipsub: select px peers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e28fbd3578e39e95019e8fb2f4c4e0782d511df3"><pre>Manifest: upgrade to irmin.3.6.1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/78d54eaf5ffb2649cd4d1c7e1c8a77094750fa89"><pre>Changelog: upgrade to irmin.3.6.1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d37e4cd95aec69c3cb9bb540e2261d70254a426e"><pre>Build: update dependencies</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e514e0c57556afa3124e14de06b5ad3a0123b0cc"><pre>Merge tezos/tezos!8063: Upgrade to irmin.3.6.1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ab9550622413344aa59633eb523abc0173ae04c3"><pre>Backport !8175 - baker: use only consensus operation with minimal slot</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c001658c08c6d1db60bdd0795ed9c1dee2f3f363"><pre>Backport !8065 - Baker & tezt: log (pre)endorsement event level and...</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e30fa3fcbae842bdcffd5111c4cfa54880e53623"><pre>Merge tezos/tezos!8348: Baker: backport changes from alpha to N</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c3bca084da88133104ab2d943481f21cf450eccb"><pre>tezos-base: remove hack for ptime</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8a3648774c6bee4d018276bca55077961285a7fa"><pre>Merge tezos/tezos!8332: tezos-base: remove hack for ptime</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/beb2a36f9f21714eb62bef1625702b09ff6c4342"><pre>Nairobi: Backport !8129</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fb1b7037f55782277d0e53c7bc72843e5877b532"><pre>Merge tezos/tezos!8368: Nairobi: Backport !8129</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/55b33ddef377a95a140a780797af6a2d57be6ecb"><pre>Alcotezt-UX: fix invocation headers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cffa9b7d9a80d2bd6d9db09b97807bf5d168e31f"><pre>Merge tezos/tezos!8271: Alcotezt-UX: fix invocation headers in [lib_p2p] and [lib_tree_encoding]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d447fcf96fc8985f7e9f0b621d686cff8d889411"><pre>doc: allow link redirect on reddit channel</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fa33dc751da97a917c82e156bf76e89a7c46f3f4"><pre>adding protocols KLMN </pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1952d92581780ac0709242c102f999f6789e30c6"><pre>docs/history_modes: replace [experimental-rolling] with [rolling]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/efc158418e821eed0d5feecb1613a7f6f17a4d40"><pre>docs/storage.rst: fix accidental single backticks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/460dfcf4db0cb59b0bebadb13ce039f7d0f0cf9c"><pre>doc: explain what stake is used for the voting power</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c2ab473704296cb28c85b36f85aded24ce9363c1"><pre>doc: fix typos in glossary/voting listings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a1b6607cbe3817e32cfd8cbbb656f65f98817229"><pre>Merge tezos/tezos!8153: doc: Typo train</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/aeae9824ed0a975a372bf6c290d66fa3c215fbd3"><pre>SCORU: Use DAC client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/efeb3ce450431e077d1313281d2431dee7c6a061"><pre>Merge tezos/tezos!8230: SCORU Node: Use DAC observer client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8fe1f88078ed8587f122ea2e6b0172e5c9289b6c"><pre>Nairobi: Backport !8227</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/331a3f28a63356e6ed2f94e6fd0cb8adf9433255"><pre>Merge tezos/tezos!8384: Nairobi: Backport !8227</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1a08c5b116d4ba3f35b20568858052eac9415c52"><pre>Tezt/proto_migration: stop logging all baker events, instead log block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3e2fd5307968022bd1284859ef922547e4804dc0"><pre>Tezt/proto_migration: set expected connection count to avoid</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/01c90b322f81002d63fb7c77ac8102e456009567"><pre>Tezt/proto_migration: revamp baker forked test with event waiters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d18cffd5d46bf2466ad988adf66b96d21642b3da"><pre>Tezt/proto_migration: do not call RPC again to check whether the block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/44ced34c9ab8aadac4daa08d88aedcc513398a4d"><pre>Tezt/proto_migration: fix disconnect</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1081ea244643e2d098396738f57e2df04ad0a3b2"><pre>Merge tezos/tezos!8115: Tezt/protocol_migration: improve baker forked migration test with event waiters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d590a4c6864e376c96dcac4bbfa0795c8b847deb"><pre>Snoop: move lib_benchmark_proto/sc_rollup to new registration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/42a4ad59dc1b04b459c47b7ad329befc3462efd1"><pre>Merge tezos/tezos!8263: Snoop: move lib_benchmark_proto/sc_rollup to new registration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e4e88bd408ef9d2431e900aba1b069979b23e404"><pre>Snoop: move lib_benchmark_proto/global_constants to new registration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4154678c54f34c7565c68fce21b6e32ca8d20ce5"><pre>Merge tezos/tezos!8311: Snoop: move lib_benchmark_proto/global_constants to new registration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e0982d196e059b2598b947a075fcb24bfe17a0d3"><pre>Context: simplify encoding using new features of data-encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bae2776910d14b7885b09604e7124be937b7edca"><pre>Merge tezos/tezos!8315: Context: simplify encoding using new features of data-encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5884ff50128e91af3a93d02b0cb04e0981775757"><pre>Gossipsub: Remove TODO as it is already implemented</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/24286b4837487c05e7f0e2aba10eb761b48d7bad"><pre>Merge tezos/tezos!8361: Gossipsub: Remove TODO</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/58a0eff6a515ffcdf7d8336dcc3d215d82b96526"><pre>SCORU/Node: fix bug in Arith PVM eval_many for dissections</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d5d72240a3fabbba0794e5d6154ab702b77ee949"><pre>Test: new regression traces for arith dissections</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a203b126b21d9850461f2fb480a2ff070f0cde1e"><pre>Merge tezos/tezos!8382: SCORU/Node: fix bug in Arith PVM eval_many for dissections</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0dddd95b12f060894ffd6ea77c4dbe7cb52d5301"><pre>proto/toru: remove apply toru error</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/94d4f7146f72504749c2a8f62aaa02ab2fde4f71"><pre>proto/toru: remove above alpha toru module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8bda6332068894523ec79f180d2c42714b97633b"><pre>proto: remove Transaction_to_tx_rollup_result</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4906fb94acf8dbf442a7480d59151b4fe4c760e1"><pre>proto/toru: assert tag of toru destination is not resued</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/aa061e407364aa37fe69ab1250e7e24806c1f994"><pre>Merge tezos/tezos!8344: proto: remove tx_rollup logic above the alpha context</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/55e5c25f9921a709add03819e39c15c1ebd6c1c1"><pre>Alcotezt: removes redundant [Unit]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cdca088b5d5249e503bc327523a7348e3b600731"><pre>Alcotezt: remove redundant [protocol]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1e2af0f695d961f729526dde8865db27c58f448a"><pre>Merge tezos/tezos!8381: Alcotezt: improves proto unit tests UX</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/433b7eb17c451b2cfdc7f9bf52c5b2d92b1975bb"><pre>DAL/GS: return direct peers in Publish\'s payload to forward them msgs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ee8e3bdb6ad2b14665a3c83f370f9e777481e529"><pre>Merge tezos/tezos!8350: DAL/GS/Worker: forward full messages to direct peers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/aa9f693fb23a00f2fd8e62f561afe40af12fc8d9"><pre>Tezt: self test michelson_script only when pred(pred(Alpha)) exists</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/84549aa095bd4e532d9fe223a2e61e8c1ebca709"><pre>Octez: Freeze Lima</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/47fd608e60a08039e03991ec2caac0b1ed72cb75"><pre>Merge tezos/tezos!8342: Octez: Freeze Lima ☃</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9049aa5eed17be9716ebb37ae9f4ef4bdfc04a80"><pre>DAL/GS: add function get_connected_peers in Introspection</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6264c14d16678eb4760f79c9c8fa15bb2d2180e0"><pre>DAL/GS/Worker: refactor p2p messages sending</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f06853e367183888b1f477a8f20885e5aec463a7"><pre>DAL/GS/Worker: handle join: subscribe, then graft</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2a67a419e9fcc6b1a5ba98e34deabbd3a48d7fae"><pre>DAL/GS/Worker: handle leave: prune, then unsubscribe</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/164525513350597fea63c9e5a73a69ab31fd872d"><pre>Merge tezos/tezos!8353: DAL/GS/Worker: handle join & leave</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6f18470da1bf699a22f5f11fc9459b530bce8ffe"><pre>Store: check history mode before opening stores</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c965849728829a6cd7b3951752e7d0a9de51a59e"><pre>Merge tezos/tezos!8281: Check history mode before opening stores</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8ac0da2ebe93c6144c5eb8c98a238f5181984146"><pre>Injector: registration module for protocol code</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/12bb184aecfa2edc458474795f10699bcc1addeb"><pre>Injector: keep next protocol information in worker state</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/338efa5d56b1831eab62aaae2ed5b02287ef4831"><pre>Injector: use appropriate registered protocol client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fa87e844b1dd1508a9671a7cbf5c8b5ffe188bf9"><pre>SCORU/Node: register protocol client for injector</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/939d2c55fdb99778804d3747879790b313b7cdb4"><pre>Merge tezos/tezos!7687: Injector: protocol client code registration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dfeef64ab1f24c235a5351bdf544130c37d3394d"><pre>SORU: EVM: cleanup unused EIP 1559 code</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9feb7b32408364ad52ff5ecfcaa2c820c7d56078"><pre>Merge tezos/tezos!8372: SORU: EVM: cleanup unused EIP 1559 code</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/292fc06229044a0b607e43ee6bc7024762f39672"><pre>DAL/GS: add a function to return the list of topics of the local peer</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ce66e6ca8847fdba183fbd4aa2dd7d4712771356"><pre>DAL/GS/Worker: handle new_connection: subscribe</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a28d06a2f9d4699ee694654043ab2afba478d92b"><pre>Merge tezos/tezos!8364: DAL/GS/Worker: handle New_connection</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7a61d731f990166b36df8dc7347156a8df44985c"><pre>Gossipsub: improve doc-strings for ihave/iwant limits</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dda30f39e32c5568654cba97cb3f8d15ee2a58e0"><pre>Gossipsub: add gossip related limits</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d8380fc6314eaecd31929e9169effb8185740f71"><pre>Gossipsub: select gossip messages</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e5fefef1c79cf233081fb60501c15634bb33a8e5"><pre>Gossipsub: add TODO to optimize select_peers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d28c49dcbdf79c1d8fbce2087ac8e8d369cae3ee"><pre>Merge tezos/tezos!8398: Gossipsub: prepare gossip</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/464b1c0c487813b8f5f1fd31ab4a5f72e1d8a25c"><pre>DAL/GS/Worker: handle disconnection: nothing to do</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e8ff076647af3d91073070bb12c635f8b1647804"><pre>Merge tezos/tezos!8367: DAL/GS/Worker: handle disconnection</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4b11e9a1ff5db5a6bcc5484c9fef4de464957b23"><pre>DAL/GS/Worker: handle graft message</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/05f22051c7de314eb91bc1cc5f639dc42c0e4afd"><pre>DAL/GS/Worker: handle subscribe message</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/59ba27571c97745c62dac01a312794c7c7920686"><pre>DAL/GS/Worker: handle unsubscribe message</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ec59589fa0a60a98e56bb8303f91a36dc4a28ce7"><pre>Merge tezos/tezos!8409: DAL/GS/Worker: handle graft, subscribe & unsubscribe</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d9ed8e82faa510b5251e003c45ec87fe3a74c942"><pre>EVM: implement [TryFrom<&[u8]>] for [EthereumTransaction]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a755d4230c6d487e09ef462bdb77b5469a6ee269"><pre>EVM/Kernel: use evm-execution for transactions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3c22111680621381af714a790aa7a352e3f59d53"><pre>EVM/Kernel: remove [RawTransaction]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/84dbeacb72a1f3c3c6f954ae17b6787fc3f25d44"><pre>Merge tezos/tezos!8405: EVM/Kernel: use evm-execution for transactions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a9bf5e98f9953ca155521de61acf9f2b1178f7a0"><pre>Gossipsub: move backoff out of connection</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d8c5120068f8c95f67ddf6d363f6f117ccbe0148"><pre>Gossipsub: more precise typing of expiring peers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/62068507d84aa9a94126ff58a8362ba9351d026c"><pre>Gossipsub: remove score and expire fields from connection</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9d32cc581be15bc902f448ee2f124bf6fb589f6b"><pre>Gossipsub/test: use Introspection getter in PBT</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0047ca71798260b14e127f22b62de1a8a0b0b652"><pre>Merge tezos/tezos!8343: Gossipsub: move backoff out of connection</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d867c0820b35df28356c95409f55110fc0bfd11c"><pre>Scoru: deduplicate RPC arg for stakers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dfaf5ec616392296ab1e2c894f718f43eabd3dd4"><pre>Merge tezos/tezos!8339: Scoru: deduplicate RPC arg for stakers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d5c2a0578b528a1d9849ddc0bed5250726d6aafe"><pre>Benchmark: fixes memory allocation benchmark failures</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1dbaa76f5f43d5b152fe2d981fd5eaaef9b0f4b0"><pre>Merge tezos/tezos!8411: Snoop: fix of memory allocation benchmark failure</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d296baa4de1c25ff8d739a226465ba5a4063e3ff"><pre>alcotezt: add unit testable type</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0d79b58034080567e327dfdb2441cf2691b3117d"><pre>hacl: port tests to alcotezt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6be21c98a6c2f74304d96c8f8a8679ddea6123b8"><pre>makefile: add @runtezt_js to tezt-js target</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c4ed57136f9d9c3cf2123ceaab313caf72a919ae"><pre>Merge tezos/tezos!7698: alcotezt: [lib_hacl]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/98d27f68fbe5bab0194fe7d631a8326680630885"><pre>Lib_crypto: Renaming Timelock to Timelock_legacy</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fdc300510f14e4ebe116040232aa16053410b8e5"><pre>Lib_crypto: Updating timelock to timelock_legacy</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2227f06704afd3b56d35539f0d6fde8b7814e000"><pre>Proto_016/lib_benchmarks_proto: Updating benchs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c7fd712a40b634e2d0d8236a0b98b33a01d2a751"><pre>Tezt/test: Checking timelock \"disabled\" only in Mumbai</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c26af1f8c0aa74cfb9142fcdbbd04c7498765cbf"><pre>Tezt/test: Updating timelock_disabled.ml</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/68bef6b9a30d870505ca5b73f0b80f31ecdb5877"><pre>Lib_crypto: Adding new version of Timelock</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6dea6fcce50a2284196d47c6e0f8141a836041f6"><pre>Proto_alpha/lib_client-lib_protocol: Re-enabling timelock</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/05d23bf12dbf7b3a5b68c5c8bf5c8c061824ce6f"><pre>Proto_alpha/lib_client-lib_client_commands: Adding client commands for timelocks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4c79d1c7ade21f2b40ffc443a16b041d35776bea"><pre>Proto_Alpha/test/integration/contracts: Adding coin toss timelock game</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4b8137100ef09368f6eb5d50f49fccb5ecc12d85"><pre>Tezt/test: Adding coin toss timelock game tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8f10129859d6be467ee3753fffd2329924d73520"><pre>Proto_X/test/integration: Removing timelock tests (now in tezt)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/92c5d1d58371966860701b327008bc1857b6814b"><pre>Doc: Updating timelock documentation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/733573a93c42e0602632313d948bc7184b956207"><pre>Renaming \"time_lock\" into \"timelock\"</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/521255de4f7855ff339ca2b4c02c3248b897734a"><pre>Lib_store: Updating test_consistency\'s demo_noops with latest environment</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/695d99f7ce3a10865e839afd490b40be842a7285"><pre>Merge tezos/tezos!8146: Updating and re-enabling Timelock</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fd5a320d93eea6e067bbc06a81cb926c71318d07"><pre>Benchmark: exports Dep_graph.Graphviz.save</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b011be54bf66d838ed56783550e31a464a2499fa"><pre>Dep_graph: adds a label to load_workload_files</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c6f554110694044cc5e4a228629626567fd82fa7"><pre>Benchmark.Dep_graph: refactoring for auto-build</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3f336e7af8beadb2db7f1ddbe858ab74c853331f"><pre>Snoop: adds Main_snoop.perform_benchmark</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/190c4543bb40516155991dcb51f89ff748fbfcce"><pre>Merge tezos/tezos!8150: Benchmark: refactors Dep_graph with better graph types for auto-build</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a62cba0c87a590697a5efc24cd1c8693999e519a"><pre>Alcotezt: split tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9c10015f0d9a46c7ef996bada8d5c13bc6aa34ad"><pre>Merge tezos/tezos!8228: Alcotezt: split Alcotezts into on Tezt test per Alcotest case</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5c34f1437b1f032b1781094adbb3aa47c2a92045"><pre>Proto/bench: remove redundant intercept benchmarks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8d63d6be574bcf713dcae2623696a8c0ad25b59b"><pre>Merge tezos/tezos!8352: Proto/bench: remove redundant intercept benchmarks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c6d7a9665cae5725d7ba373de979b23dc15cca88"><pre>Tezt/external_validation: fix flakiness</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/289c74cb7c7312e6f7ae472c8d14af7251437af9"><pre>Merge tezos/tezos!8333: Tezt/external_validation: fix flakiness</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/646ad6b3ecdad46347f5ad12aa190920bdf27825"><pre>Kernel SDK: switch crate names to kebab-case</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/25ae175d63a20fd3fe494d8a2301102b07b023ec"><pre>Merge tezos/tezos!8378: Kernel SDK: switch crate names to kebab-case</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6220831a714a64b2d201e458d2721db0b152f4f7"><pre>EVM on WASM: ORIGIN opcode. No panics on other opcodes.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c95666285efecf6e8a3f72b4e7940cdc77e5c726"><pre>Merge tezos/tezos!8314: EVM on WASM: Support ORIGIN opcode for the EVM.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cd1fd670ec8e4b73f0341ecaf8355f8f04256160"><pre>SORU: EVM: fix a decoding bug</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/05eac78efe1772134d87a676b6d5363143fd7c58"><pre>Merge tezos/tezos!8340: SORU: EVM: fix a decoding bug</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/095e545814046a04c35b3db8fa9cc851ca46b2d2"><pre>WASM PVM: Introduce a new directory to write regression tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d4bd8871e50705606b67401a991aadfed90a4862"><pre>Merge tezos/tezos!8374: WASM PVM: Introduce a new directory to write regression tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/709ef092e19fc6014abdf1b67aaa6120cbf92ca2"><pre>Kernel SDK: remove store_get_nth_key</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/798cff8759d5a5049db326d7292d79add838dd96"><pre>SCORU/Docs: remove references to store_get_nth_key</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/75fe7e0e7dd7ada34f3fa9d4f7c6c3f5d2441d8e"><pre>Merge tezos/tezos!8306: Kernel SDK: remove store_get_nth_key</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/74eea646802fc2048f65a85fec60a95b3c59b1bf"><pre>SCORU/Node: synchronize Nairobi rollup node with Alpha version</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9bf1ae5fc381578bf396281a53df562d13033c3f"><pre>Merge tezos/tezos!8383: SCORU/Node: synchronize Nairobi rollup node with Alpha version</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0dd514503c911c85070f524fe7f96b7c59dcf1dd"><pre>WASM/PVM: rename \`Subtree into Directory and make it a variant</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/46952ce9b490e1d43c49d8da92613970f28f66aa"><pre>WASM/Durable: \`delete\` can remove only the value if asked</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1e760727a5f2c6a8812775e9679fa110b70eda0e"><pre>WASM/PVM: add \`store_delete_value\` host function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/21930a33c2bd7848eb1c2fb051e1f75e5e7e6107"><pre>WASM/PVM: test \`store_delete_value\`</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a2f7a43ab1188c08f547e6a3f9091ba0a4e6722d"><pre>Durable: Revert the snapshot back to its initial interface</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/70761e68cd6a2c423ada78bf0194bdf79178aa91"><pre>WASM/PVM: update regressions for \`store_delete_value\`</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bc08411a8a1301056aef8f062099952490debe5d"><pre>Merge tezos/tezos!8307: WASM/PVM: add \`store_value_delete\` for version V1</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/3cac2aff599c654f791b0315fc1391c84c30aeb5...bc08411a8a1301056aef8f062099952490debe5d