### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1681303793,
-        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
+        "lastModified": 1681648924,
+        "narHash": "sha256-pzi3HISK8+7mpEtv08Yr80wswyHKsz+RP1CROG1Qf6s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
+        "rev": "f294325aed382b66c7a188482101b0f336d1d7db",
         "type": "github"
       },
       "original": {
@@ -171,11 +171,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1678898370,
-        "narHash": "sha256-xTICr1j+uat5hk9FyuPOFGxpWHdJRibwZC+ATi0RbtE=",
+        "lastModified": 1681303793,
+        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac718d02867a84b42522a0ece52d841188208f2c",
+        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1681227715,
-        "narHash": "sha256-kQZOoTa177VF5uk1JK7bA9ZTU5g6d5IuDp/6YdxUWao=",
+        "lastModified": 1681413034,
+        "narHash": "sha256-/t7OjNQcNkeWeSq/CFLYVBfm+IEnkjoSm9iKvArnUUI=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c77e64a5adab96866ea97449a5a7a327d4629828",
+        "rev": "d3de8f69ca88fb6f8b09e5b598be5ac98d28ede5",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1681326733,
-        "narHash": "sha256-DR0muG0/3gj2fUa4wWAgfdYSMPeEZfADCdflvTJFdfk=",
+        "lastModified": 1681562627,
+        "narHash": "sha256-1ocSJYuuZfR0eOKfUtI3z6SZMyu5PailFYk9H3yOyvU=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "45337738d7558ab0e31ed42b0ab250e472cbe75b",
+        "rev": "f2db1702d0f45566db5c5480bdc24fa9d15f60e7",
         "type": "gitlab"
       },
       "original": {
@@ -258,11 +258,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1681115235,
-        "narHash": "sha256-VCETW6vOzNlByc0A5gTJoFE9L/ikP91rX6XynBUgIno=",
+        "lastModified": 1681486253,
+        "narHash": "sha256-EjiQZvXQH9tUPCyLC6lQpfGnoq4+kI9v59bDJWPicYo=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "f3dd071be31528261034022020fc7e4c010f7179",
+        "rev": "b25d1a3c2c7554d0462ab1dfddf2f13128638b90",
         "type": "github"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230413";
+    octez_version = "20230417";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/fdf16835e47fddc8697e47d50acb00387c44bb00"><pre>SCORU: Node: Remove mainnet check</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b52ef1aaf874f915c7746d3183700c52f082f415"><pre>Merge tezos/tezos!8346: SCORU: Node: Remove mainnet check</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c975f397c15c902c541ff04b3b4eed3f5b65fb48"><pre>WASM: Supply preimage hash in reveal preimage test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/03fcfd01e936058b27491640b74aad2864c3857b"><pre>Merge tezos/tezos!8433: WASM: Supply preimage hash in reveal preimage test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e278f33d0d9389b5d4e54e0874feac28b232d56c"><pre>doc: add manuals for smart rollup client & node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/56960446f4cf765250076c0c278e186f2f0009c3"><pre>Merge tezos/tezos!8386: doc: add manuals for smart rollup client & node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/95eeb3e9ee89b1eabf981fddcb79b3b9a439b188"><pre>WASM/PVM: add a note to depreciate \`store_get_nth\` host function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8b1d7e3303139ed11ddce79476c4059f1f99fbc6"><pre>Merge tezos/tezos!8458: WASM/PVM: add a note to depreciate \`store_get_nth\` host function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/41f18045ebe9fcdc54e5046796a59f65ca117b7d"><pre>Makefile: Add [runtezt_js] to [test-js]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/798d11c6d20468ecb1b2a8a7c430f33958777606"><pre>Merge tezos/tezos!8449: Makefile: Add [runtezt_js] to [test-js]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8a43d56c86fd27f61a23cd549f3b803166dfa6ca"><pre>DAL/GS/Worker: implement worker shutdown</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0dc4b19feac50a33fc5272d2c1b1114de7f2e724"><pre>Merge tezos/tezos!8160: DAL/GS/Worker: implement shutdown</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/46982a493080bbf26aa3ed317d97f61ca5fff5ed"><pre>TPS evaluation: fix build</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/56a76ce1f2b626a6fcbbf53366695fcd54d317f5"><pre>CI: Test lift_limits.patch</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/09c478773ca9c2726682b2fecfc85ec6f2356208"><pre>Merge tezos/tezos!7884: TPS evaluation: fix build</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1e208bb48d183ad7c0721959e17ec844c1da97e9"><pre>doc: link from pruning doc to operational details in v15</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6ab649d5a05857426f7b761d3867702b7042bb04"><pre>Merge tezos/tezos!8406: doc: link from pruning doc to operational details in v15</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5a2b1177619e10b6a31cecb1816f6b19f47766bc"><pre>Gossipsub: Fix bug in mesh maintainance</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b67b81b8a496e755214a68ddbb51141128692251"><pre>Gossipsub: Remove peer from mesh and fanout on unsubscribe</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/371c84ab8897bfd46c23d8ee8a0bda5dbdb63433"><pre>Gossipsub/Test: Add test for removing peer from mesh on unsubscribe</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ed1094244997b2ecb5b9a023b2efea9857cc7517"><pre>Merge tezos/tezos!8450: Gossipsub: Remove peer from mesh and fanout on unsubscribe</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3750ead6d50295a3db5118a90ebff530a802f7e0"><pre>Docs: Complete smart rollups Changelogs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a7552d56915c3eff9a6fcdf09b0aa877468b12b4"><pre>Merge tezos/tezos!8439: Docs: Complete smart rollups Changelogs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/feb439bee0bcbd4aa711417dc251a06ca3a96338"><pre>Scoru,Node: fetch context outside the inbox module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/301dcd1e3eff3cd5595f1148c2f7677e113af465"><pre>SCORU/Node: Backport !8453 to Mumbai rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/626b89225d69290fe5027c58386cf33cf879febe"><pre>SCORU/Node: Backport !8453 to Nairobi rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/314716d51d3d86365a28d93d164ff8d7894f03e3"><pre>Merge tezos/tezos!8453: Scoru,Node: fetch context outside the inbox module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b110b5b2f5ba77735de7c56514154a5b388aea01"><pre>SCORU/Node: use a lock file to prevent access to rollup node data</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/29cd7b66657843ad4b67e8e0e8139e0b243730c4"><pre>SCORU/Node: Backport !8447 to Mumbai rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9cb23653455cd6af7b49542f5965f62f38da0d4a"><pre>SCORU/Node: Backport !8447 to Nairobi rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/34a1ff0aa31e7a67fa41ba6126c238d71aee7e8c"><pre>Merge tezos/tezos!8447: SCORU/Node: use a lock file to prevent access to rollup node data</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ac4a09f7207112ae1903c67e092a7350a60c2b66"><pre>DAL/GS/Worker: handle Heartbeat event</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/909adee042422a56c1c12bbfcd412c70d9407fba"><pre>Merge tezos/tezos!8437: DAL/GS/Worker: handle Heartbeat event</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/684546beaa7f50b06327e6092a3aa60e7fd5b1d0"><pre>Revert \"Logs: set default daily logs directory at XDG specified path\"</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fa5cbe969a2762b826fa029b6ac5dbe07fa7ea69"><pre>Revert \"XDG: add XDG_path module to deal with XDG specs\"</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/44ce0a32ccbb51d99d1db17c511c288e940b1a82"><pre>Merge tezos/tezos!8478: Revert \"Logs: set default daily logs directory at XDG specified path\"</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f2eabc0de38c910762447cdc95c27ba775042f88"><pre>Docs: Reset Alpha changelog now that Nairobi has been injected</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a151c14b414c5ef035cd4de7ef153751e8eb1e85"><pre>Merge tezos/tezos!8474: Docs: Reset Alpha changelog now that Nairobi has been injected</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f12e2e9a47c01b797b7eea5b3c2a4fc476a96dd7"><pre>Lib_proto_environment: Update env with timelock_legacy</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8c6b89253ba858cde84a1b842ab1ef361fe4bd4c"><pre>Proto16/lib_bench: update to timelock_legacy</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0b59c4f1d6a8919f4ff9d6bcc75f645d990ab36d"><pre>Merge tezos/tezos!8476: Timelock: fixing env</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bd16ef69bd18ef40ec1e88ed3a09a6aac5938400"><pre>SCORU: Add option to direct kernel logs to file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/05de772ec7485990254fb8b267584b6625c50c37"><pre>Merge tezos/tezos!8277: SCORU: Add option to direct kernel logs to file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/70ee59dac6c6ab384b72a843dddc3b6053cd4a7d"><pre>DAL/GS/Worker: rename \'msg\' to \'output\' in emit_{p2p,app}_msg</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/edfa7fb3c40d92676341bd602218d276e76c57cc"><pre>DAL/GS/Worker: re-export Config modules</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9de94a7d9a4b6c7fbb41b90264c4d4d130cadbfa"><pre>DAL/GS/Worker: Stream.empty takes unit as argument</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/21fbb1ca5fb94e2c6f1f3dd93a2fd60fa082bb25"><pre>DAL/GS/Worker: export p2p and app output streams</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/61d7f72501028852b97271ed4720c4973f3a5f89"><pre>DAL/GS: export the Worker functor in Tezos_gossipsub</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/789ee7d987b3866e321600aa76c0d5c4b703b50b"><pre>Merge tezos/tezos!8467: DAL/GS/Worker: refactoring and interface improvement</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/19a8577d2a6b5c49e57b274b50aa40ecf80ecafb"><pre>Proto/Michelson: compound{1,2} at the level of metadata</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d81c08281bf7a00f811de44e906c980631c897ab"><pre>Proto/Michelson: restrict type of unsafe meta_compound functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9cfa9b85e7f1cb097d1713fa033497aa5e009c10"><pre>Proto/Michelson: same for meta_basic</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7490d9e3dc967641144f717f5bbacf34c30561dd"><pre>Proto/Michelson: toplevel asserts replace Type_size.{two,three,four}</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/65ae80cb233ac91fc925607491be1371f1dbb727"><pre>Merge tezos/tezos!8420: Proto/Michelson: refactor management of metadata in ty smart constructors</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5e2dc350673f3155cbaf19066510df5bcd8ec8bf"><pre>Benchmark: fixes the type of Config.edit_config</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/217cdbeec29451a2567e73b705db6302e8590394"><pre>Benchmark: adds Config.{pp,build,save_config}</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ebe5095840cbdf4192266d791c37750c5e0b539f"><pre>Snoop: expectation test fix</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dc3c76f5021dd75e63d39663d6ba73186dd8fe4c"><pre>Merge tezos/tezos!8363: Enhance Benchmark.Config</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a8df997f24c6a8a922871b32a2db02608711b697"><pre>Docs: Update smart rollups documentation for Alpha and Nairobi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f2db1702d0f45566db5c5480bdc24fa9d15f60e7"><pre>Merge tezos/tezos!7875: Docs: Update smart rollups documentation for Alpha and Nairobi</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/45337738d7558ab0e31ed42b0ab250e472cbe75b...f2db1702d0f45566db5c5480bdc24fa9d15f60e7