### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1681648924,
-        "narHash": "sha256-pzi3HISK8+7mpEtv08Yr80wswyHKsz+RP1CROG1Qf6s=",
+        "lastModified": 1681737997,
+        "narHash": "sha256-pHhjgsIkRMu80LmVe8QoKIZB6VZGRRxFmIvsC5S89k4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f294325aed382b66c7a188482101b0f336d1d7db",
+        "rev": "f00994e78cd39e6fc966f0c4103f908e63284780",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1681562627,
-        "narHash": "sha256-1ocSJYuuZfR0eOKfUtI3z6SZMyu5PailFYk9H3yOyvU=",
+        "lastModified": 1681795539,
+        "narHash": "sha256-1utrKwQ6BsUIrf3PZG4CVdRflCzVeMuoMD0vryk+bQc=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "f2db1702d0f45566db5c5480bdc24fa9d15f60e7",
+        "rev": "a1b1f68b20e9fae14df3d1f5ea64f6cfe3d535df",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230417";
+    octez_version = "20230418";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/77d9e6f685f075d8bf98be1cfdc02c2ff7d2e435"><pre>Benchmarks: remove current_run_dir.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/63a9f4e5378a006c6a1dee6f3e1cc06551cfa650"><pre>Merge tezos/tezos!8418: Benchmarks: remove current_run_dir when starting a run</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9230942b1c4da240288091e6ed5f982075dab1fb"><pre>Nix: Mac: Add missing Security framework</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b5057f600a0bbe7b7fc9c411bf3bc0b0ea561b93"><pre>Merge tezos/tezos!8471: Nix: Mac: Add missing Security framework</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b9e8cebcb062f3a5cb7d2075dddded66611daf67"><pre>Alpha/Accuser: fix consensus denunciation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2483e5d187f88477987878a237082ef16f5f12b3"><pre>Alpha/Accuser: misc. refactors</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dc70381f8c2c8c9297b13766f92d6f2d8786c264"><pre>Alpha/Accuser: only monitor applied and branch_delayed operations</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7fec0ca3594ed5f72a54c431c5bb308e659f18f2"><pre>Nairobi/Accuser: backport accuser changes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b79c919eb1b6ada48f423c4de715718ba70db373"><pre>changes: add an accuser entry for double consensus with multiple</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/054cfe3b83c7e1e651d16084039fb3d72081c484"><pre>Merge tezos/tezos!8084: Accuser: denounce consensus operation with different slots</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4d1ad6aba69687a70693c2ad842bf5c574793908"><pre>CODEOWNERS: Remove @ole.kruger from rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/29e733482c9630c314a65baaa0499eb585c44945"><pre>Merge tezos/tezos!8316: CODEOWNERS: Remove @ole.kruger from rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/55a3a5543fccaf0f95ec39d2e4f2d13182f1592c"><pre>Injector: count errors per operation for failed injections</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9177242a35061d32ca24ba44492eb9b121c883c4"><pre>Injector: drop operations which errored more than allowed</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f5696cbc7e5803bef648c40a77b19a018f685186"><pre>SCORU/Node: configuration option for allowed attempts of injector</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/26c89157ef0447fc7a057a421f786b8365a97f85"><pre>SCORU/Node/Injector: retry temporary/branch errors by default</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ba5e42eb91f065671526ce6715e3ceeec45fa2ce"><pre>Test: check that injector discards repeatedly failing operations</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cd3d0a8dde33f7c52be98a7675f62a8cdd8b76ee"><pre>SCORU/Node: Backport !8272 to Mumbai rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b0eb3f801dc30d3524041b9862d4b604218420d3"><pre>SCORU/Node: Backport !8272 to Nairobi rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e2e60e3003f7a42a5d423bb531416f70f3eaa5dd"><pre>Merge tezos/tezos!8272: SCORU/Injector: discard operations which fail too many times</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2ad08b10bb1fdf48d3bd9a1d5b38db3e0f3ecf8c"><pre>Injector: keep track of injection level</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/733c4134305c96351f06d54325f821f154aed3cf"><pre>Injector: retry operations that are injected but not included</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/10b6bae25001145cd8228c52ac5e1f980f9ba32d"><pre>SCORU/Node: configuration and CLI option for injection ttl</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/79667752ab8e667c2ad063e6ea767f1024149125"><pre>Injector: introduce records for internal types instead of tuples</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5a98f28d450e672d5a24a61d27296e37c8c8e4d1"><pre>SCORU/Node/016: configuration and CLI option for injection ttl</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/08f52a156f807d91552840a7f3376b3edc0586a2"><pre>SCORU/Node/017: configuration and CLI option for injection ttl</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/86b0c20ece7b9a54c91d1bdec038c103034ff2eb"><pre>Merge tezos/tezos!8359: SCORU/Node: warn of never included operations</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ba365f576e718d730d55bc59a346eb4b18936eaf"><pre>Gossipsub: Reorder functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f03c61a853d66cd50a2843d1a332a146f5d9afcb"><pre>Gossipsub: Subscribe in graft</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b76c3b2bebadc128c90de4d8dcabe20bf17ddd21"><pre>Gossipsub/Test: Add tests for subscribing in graft</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d3f7944434935ec0599391c3396d6d1543f56634"><pre>Merge tezos/tezos!8472: Gossipsub: Subscribe in graft</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/74c05cca51144d4f2c3a97cf52cb7a1c0eafc6b9"><pre>Benchmark.Fixed_point_transform: adds interface</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6e12a362deaae4c9a93c2f3bd08b699542d1e7a5"><pre>comment fix</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6f9e04b9d695890c38b610e04c40a0cb2f640467"><pre>fmt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a1b1f68b20e9fae14df3d1f5ea64f6cfe3d535df"><pre>Merge tezos/tezos!8402: Benchmark.Fixed_point_transform: adds interface</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/f2db1702d0f45566db5c5480bdc24fa9d15f60e7...a1b1f68b20e9fae14df3d1f5ea64f6cfe3d535df