### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1681413034,
-        "narHash": "sha256-/t7OjNQcNkeWeSq/CFLYVBfm+IEnkjoSm9iKvArnUUI=",
+        "lastModified": 1681831107,
+        "narHash": "sha256-pXl3DPhhul9NztSetUJw2fcN+RI3sGOYgKu29xpgnqw=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "d3de8f69ca88fb6f8b09e5b598be5ac98d28ede5",
+        "rev": "b7ca8f6fff42f6af75c17f9438fed1686b7d855d",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1681795539,
-        "narHash": "sha256-1utrKwQ6BsUIrf3PZG4CVdRflCzVeMuoMD0vryk+bQc=",
+        "lastModified": 1681851094,
+        "narHash": "sha256-M12wL6lfAq1yLD3A0pkMaU0YWV8nmX1ovWM+hKK7ZzE=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "a1b1f68b20e9fae14df3d1f5ea64f6cfe3d535df",
+        "rev": "ff1bdfcdf596382193d268fdaf62e088102a19ba",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230418";
+    octez_version = "20230419";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/38c49cb4241d0a36de125abd29cad284d13efc17"><pre>DAL/GS: add noPX_peers in Leaving_topic</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/512432cce5d47f2aeacf33c18c933b768f874f2f"><pre>DAL/GS/Worker: when leaving a topic, send prune messages with correct px</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/513f392529e8ee7501e4ba487624832353b45c85"><pre>Merge tezos/tezos!8484: DAL/GS: send alt PX when pruning a topic after a leave</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a9524bf1391672c8e10568906122aa4b956e8a48"><pre>Unix: adds syslog primitives</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/63cfd8be82dd0fab36e34b78c933ef7b326cf0b7"><pre>Unix: adds test for unix syslog implementation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f3fb83b3ddbcf48fd122bde26adde7c972a7d0d6"><pre>Merge tezos/tezos!8172: Unix: adds syslog(3) functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6f00ae457251759ba2cf7e6d1f9a7563b246c5c2"><pre>lib_plonk circuit gates: generalize [equations] to take an array of wires</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ae158908cf5254b0fac81cc10d7cfdee517a90fd"><pre>lib_plonk circuit gates main test: change structure of wires</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6d47daf992ede43d2f338b2e3904ba430f5bba78"><pre>lib_plonk test: remove unused wires in test cases</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/03440ebcb1c0888d3e79e587959041cca0f49c26"><pre>lib_plonk gates: generalize [cs] to take an array of wires</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/008feb0f5628852a760b7e1bc4a57722b69a14cd"><pre>lib_plonk gates: remove ungeneralizable legacy wire names</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/44ea45df5ebe63b979a72e131ba98e09b66dfcda"><pre>lib_plonk gates: generalize [get_answers] and [get_evaluations]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/12a6a2199404d5873241f72ed2859a2cafc573da"><pre>lib_plonk gates: generalize inclusion of arithmetic monomials</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c74af44d6e956329c2f6bd22c1ba094ae9f433cc"><pre>Merge tezos/tezos!8258: PlonK: generalize the number of wires in the architecture of PlonK - Fixes #5273</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0585cb83ec44912a8827c58fe18f4a6a162f743c"><pre>Test/Proto: Solve the PoW baking challenge when producing a block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f62c1ad98ec8911f7c24601e6a6abcf3d96221bb"><pre>Alpha parameters: Require just a bit of PoW to the baker in sandbox&test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4663f4cbc8309942cf406831db7e2ef1c55b505c"><pre>Baker/Alpha: Improve Proof of work efficiency</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/80be28399ec2b4db4795e40f06dcfeaaf37ef8c5"><pre>Baker: Backport in active protocols Improve Proof of work efficiency</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b786a476548d494140f75e43a184179a11124e50"><pre>Client/Alpha: add a command to bench baking PoW</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7e259b0662bd8f466d00eab41db396ff692dd111"><pre>Changes: add entry for Baker PoW</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/759aa6d9ba22db618642161f702a8fd4e8de410b"><pre>Merge tezos/tezos!8403: Improve efficiency to solve the baker PoW challenge</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d7727691cbf4570c9c32918fc5e2b6bec61adc12"><pre>doc: deprecate Yay in the doc</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1a153f0c92b07e5dbfddf7008a556b3c5532ad38"><pre>doc: deprecate Yay in generated doc</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cacc94d68a313d005baa7abe2f0de8ebbae9d79c"><pre>doc: add changelog item for Yea/Yay</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c3e90794097f097f046d95af655fa4a656ab48ab"><pre>doc: backport changes to Mumbai and Nairobi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6f8bcdb8512917b5e9c83b8121f8f6c48958e496"><pre>Merge tezos/tezos!7960: doc: deprecate Yay in favor of Yea</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/82e483d2686f2bca9626597cb1cca46fbc95a78e"><pre>SCORU: Node: Improve error reporting for bad reveal hashes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6efb4276eb66dd9e6871ce74c65c16aa05a69f36"><pre>Merge tezos/tezos!8488: SCORU: Node: Improve error reporting for bad reveal hashes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4cc96d6a486b780d239caf7493008cb0e309f0d4"><pre>Alcotezt: automatically add proto tag</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/785603c5598aa77d3ca253544b04ea3502b8a2ea"><pre>Merge tezos/tezos!8390: Alcotezt: automatically add proto tag</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cd5461a3fea9bdeeaa1b5299503ab16479992d1a"><pre>Shel/DDB: Do clean former p2p reader</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fb202ea2b1c59a9add8b4f7fa2426696e2ed9580"><pre>Merge tezos/tezos!8485: Shell/DDB: Do clean former p2p reader</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2423c46cb96b80fc4a377caab3734a43e1934729"><pre>Doc/Michelson: redirect special operations to interactive reference.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/daab6c799a1dd8f2c3fb72b0e00c5155a6691988"><pre>Merge tezos/tezos!8302: Doc/Michelson: redirect special operations to interactive reference</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/09f2abbc18c041ea3373e04e375bb05ed4b580af"><pre>P2P: fixups in metadata</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7c293c64b6adbf8306ea5547b3bda8a8a3d63335"><pre>Chain_validator: Advertize only head when switching to a sibling</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6de878e55a28a57a48bb2aa27e5eac2ee8784dc9"><pre>Peer_validator: Do not launch a bootstrap pipeline to validate 1 block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ff1bdfcdf596382193d268fdaf62e088102a19ba"><pre>Merge tezos/tezos!8492: Chain_validator: a bit less notify branch</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/a1b1f68b20e9fae14df3d1f5ea64f6cfe3d535df...ff1bdfcdf596382193d268fdaf62e088102a19ba