### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1681920287,
-        "narHash": "sha256-+/d6XQQfhhXVfqfLROJoqj3TuG38CAeoT6jO1g9r1k0=",
+        "lastModified": 1682181988,
+        "narHash": "sha256-CYWhlNi16cjGzMby9h57gpYE59quBcsHPXiFgX4Sw5k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "645bc49f34fa8eff95479f0345ff57e55b53437e",
+        "rev": "6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1682015645,
-        "narHash": "sha256-ZOCGwHbl6/BGO7bgGVMdYOxefP8LcVO2aMdYz5DImu4=",
+        "lastModified": 1682132149,
+        "narHash": "sha256-znerCGL9Zk+n+HjOsgc4sG4yjrqrVn3QMMsrx3xEQIc=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "4776c98234be5c487b8df89b964b1d482db49971",
+        "rev": "9b10efc7bc146cd39f5565c1f2179ae8c3ee57ea",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230421";
+    octez_version = "20230424";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/2fc2220edc7cc3623ca506bb6efa13d74a2585a5"><pre>EVM/Kernel: remove the notion of ValidTransaction</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d1e9ed96c62f36815fb02d00fd7ca73ff9299d32"><pre>EVM/Kernel: omit the gas payment when applying a transaction</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f3989a3a563e89a1a0c295cb028d3fc77e7f904d"><pre>EVM/Kernel: make a failing receipt in case of invalid transaction</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7953ceda17340986c3aa0b60cab7d1742e6518f2"><pre>EVM/Kernel: read transaction receipt\'s status</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d7d6c5c6a168f1d2f6accfc842fe19f48a75bc78"><pre>EVM/Kernel: test of invalid transactions producing failing receipts\' status</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9d76fa16b84d23801bb1f0c54fd6db0e71f514aa"><pre>Merge tezos/tezos!8441: EVM/Kernel: allow block production with potentially not fully valid proposals</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/57b7089e0a765870374212d2e0b99b52e046d416"><pre>Build: update dependencies</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e37bc9af2d7cc15431a81f2dfff924202e0ffcc5"><pre>Docs: update Python version to 3.10.11</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d48f63bae31447118f00db38bdcb36c44bad46b9"><pre>Manifest: avoid conflict duplication</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4b233a33f3ba079a79f3134387243a178fc5cb3c"><pre>Manifest: add checkseum.0.5.0 conflict</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/68b949aae3ba727f67afc1712c1c0211e0706690"><pre>Manifest: move hacl_x25519 to the Conflicts module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6c19b32cef894c7013716d0e1b26f3d3f8c213de"><pre>Merge tezos/tezos!8455: Upgrade to checkseum.0.5.1 and update the world</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f4c6583cbfd68ef18cba0b1a04c5e4106f62add7"><pre>Logs: move default logic from node_config to base_unix</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2295b6c39fe62e9eae4be0be30eac2ea4001ec4c"><pre>Internal_event_unix: simplifying interface</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cf0642a3580d99a2f381bafcff21f4d58477a114"><pre>Internal_event_unix: improve naming and documentation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/912821cb6008e42029c8b40f786038549efa8655"><pre>Client: make client aware of sink config and add daily logs path</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/286e13e375e917ddbd495c83412edf34c170b57d"><pre>Merge tezos/tezos!8241: Client and logs: refactor both to enable internal_events config into clients</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/660ca2386b920e9eb0cd6db2efa5874cf51575a8"><pre>CI/Tezt: introduce tag [ci_disable] and use it to deselect tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a8cd7274efa64b42f0d7bb15551f6f54e25e4ce8"><pre>CI/Tezt: disable \'external validator kill\'</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/339eb2b98bb15a8faf0e0c0b555cfd28e0de00f6"><pre>Merge tezos/tezos!8519: CI/Tezt: disable \'external validator kill\'</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3c1d18fc8e52f19d526f10e72c41fa6c5d154e80"><pre>Kernel SDK: key count is nonnegative in ok case</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6bff2c030e50787492f8d533ff2d936d0a58901c"><pre>Merge tezos/tezos!8487: Kernel SDK: key count is nonnegative in ok case</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c63b4bdfcc21c54a618ec15f1ebf4450c95fc610"><pre>SCORU: Wasmer: Shut up Ctypes\'s incorrect funptr leak report</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6ed773da9d4af32884d7e9ede01867285f0d5f21"><pre>Merge tezos/tezos!8512: SCORU: Wasmer: Shut up Ctypes\'s incorrect funptr leak report</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/80e682f10b8418d79ea76c65a4672729c64a5941"><pre>Kernel SDK: prepare tezos-smart-rollup-core for publish</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/926c59ff3daf7f2846326d554f8f2063cb87ca46"><pre>Kernel SDK: prepare tezos-smart-rollup-host for release</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bb47e24cababe336872e8316ca1327289b826f53"><pre>Kernel SDK: prepare debug crate for release</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5ec1dad4347d901c08946ab11b178caf15a9b848"><pre>Kernel SDK: prepare panic_hook for publish</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5e3b4522b0f2525a69962e674fe8b5ca7d79e85d"><pre>Kernel SDK: prepare entrypoint crate for publish</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b83f4ef7d0d96d85b45d87ca1b79388a4c4dc6cb"><pre>Kernel SDK: remove encoding/mock dependency cycle</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a14a389f9a59f3772e60235939c11516df976295"><pre>Kernel SDK: prepare encoding crate for publish</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d08ef4dca88b6fba2722e0dabcc0909606e9116f"><pre>Kernel SDK: prepare mock crate for release</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/11866d14c70b16fd165493a3182bebe573ffc0a0"><pre>Kernel SDK: prepare storage crate for publish</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/35b772b11abfd8761a34f44b9ffbb19aea13a248"><pre>Kernel SDK: prepare top-level crate for publish</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6bba1c07fbec4311735c06ab2e6cf400b3970f07"><pre>Kernel SDK: prepare installer client for publish</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a90bae86b1942b96b00691d392e2a2ad08a7f73e"><pre>Merge tezos/tezos!8526: Kernel SDK: prepare all crates for alpha-release</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f2ac3865bc0ee3ffa6739fc745f0cbe8e441e98e"><pre>Dac/Coordinator:add certificate streamers to signature manager</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b4475a04bc333850a9e0e097be0b997b5a2a2aba"><pre>Dac/Coordinator: Stream certificate updates</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9ce50af2a300021bfbbe719ad88e4fa199a71bfb"><pre>Dac/Monitor services: add monitor certificate endpoint</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c8ece87f759f13bf89fcbf72e70426afbed31438"><pre>Dac/Coordinator: handle monitor certificate</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bc258cc742c60215b42a40439f05e5d9834c2733"><pre>Dac/Coordinator: stop streaming certificates when all signatures have been collected</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a804dbafe9ef18217c6cb0ed4c54c3d8540c639f"><pre>Tezt/Dac: test streaming certificate endpoint</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/53532da66c51b4a255e0b0a0a4ab5c27eb3e4eb4"><pre>Dac/Signature manager: refactor handle_dac_member_signature</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dfb5523d97789b2096482b202bca705e1becf376"><pre>Merge tezos/tezos!8491: [DAC/Coordinator] Streamed endpoint for pushing certificate updates to clients</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ae029bb7fde9b39ea72100c440d6b0abb2449df8"><pre>doc: simpler UI of home page</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/50e79f9826396ac59d2d574e665c1a583fe16ff4"><pre>doc: make images clickable</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f59d4f1fbf002a0a6c1e70bbf5aec94ec7a38f6c"><pre>Merge tezos/tezos!8325: doc: simpler UI of home page</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5a71c86ad82634889b38a36bddc3b13a6767e245"><pre>shell.nix: put kernel-specific rust/cargo version first in path</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f447cc7e0f775b7978f3406d53b9f3d7625eb829"><pre>Merge tezos/tezos!8534: shell.nix: put kernel-specific rust/cargo version first in path</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/28153f3825b6dbe3771151f21da9c572a2cb4ffa"><pre>Benchmark: removes unused code from Dep_graph</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9b10efc7bc146cd39f5565c1f2179ae8c3ee57ea"><pre>Merge tezos/tezos!8452: Benchmark: removes unused code from Dep_graph</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/4776c98234be5c487b8df89b964b1d482db49971...9b10efc7bc146cd39f5565c1f2179ae8c3ee57ea