### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1682181988,
-        "narHash": "sha256-CYWhlNi16cjGzMby9h57gpYE59quBcsHPXiFgX4Sw5k=",
+        "lastModified": 1682453498,
+        "narHash": "sha256-WoWiAd7KZt5Eh6n+qojcivaVpnXKqBsVgpixpV2L9CE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c43a3495a11e261e5f41e5d7eda2d71dae1b2fe",
+        "rev": "c8018361fa1d1650ee8d4b96294783cf564e8a7f",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1681831107,
-        "narHash": "sha256-pXl3DPhhul9NztSetUJw2fcN+RI3sGOYgKu29xpgnqw=",
+        "lastModified": 1682326782,
+        "narHash": "sha256-wj7p7iEwQXAfTZ6QokAe0dMbpQk5u7ympDnaiPvbv1w=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "b7ca8f6fff42f6af75c17f9438fed1686b7d855d",
+        "rev": "56cd2d47a9c937be98ab225cf014b450f1533cdb",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1682132149,
-        "narHash": "sha256-znerCGL9Zk+n+HjOsgc4sG4yjrqrVn3QMMsrx3xEQIc=",
+        "lastModified": 1682451919,
+        "narHash": "sha256-AQ+2xEUKuG0b2YWVFOqEvl/5AcZcwykaAjkXC7eLlGE=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "9b10efc7bc146cd39f5565c1f2179ae8c3ee57ea",
+        "rev": "c420fc7d3b59e287ca1978d34c944503d5a5bb9e",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230424";
+    octez_version = "20230426";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/7735ba293456e0599e4b0da51d363fe9497640b6"><pre>Scenario: authorize no snapshot provided</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bab5b9c9e9050a765c224cd71f35b58d6b0643f5"><pre>Merge tezos/tezos!8523: Scenario: authorize no snapshot provided</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5dcba8dfa17734eb0b3b94b3c43e1dc0685b1eef"><pre>Proto/Michelson: document when legacy behaviour was introduced</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0a640e08a091694d0bb4e3dbe8bc1ee36ff8aa20"><pre>Proto/Michelson: rename legacy to allow_contract for check_packable</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9d157db1639b3af463af1fc8bbcc58f730bb13ef"><pre>Proto/Michelson: disallow non-packable types on FAILWITH</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1f85187cd891a6a0273dbc58429992f9da40e4fc"><pre>Proto/Michelson: contract is not packable in general</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/06240007b25c075f84136da94de00834401f792c"><pre>Proto/Michelson: contract is not storable</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6770a854ad5f45766c83ea4650706ebe2d769539"><pre>Proto/Michelson: disallow contract in big map values</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7c2d3d70c2725afd6c6199552e16d6546c3d2660"><pre>Proto/Michelson: disallow contract in EMIT</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2179b72a4dbcd8edce9fdebb117ff445a310e4f4"><pre>Merge tezos/tezos!5800: Proto/Michelson: remove legacy behaviour related to contract type</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ac1971ba15a8367758484c0047c5020f5283f99f"><pre>EVM/Makefile: \'make\' test in order for the CI to fail on errors</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/872bb31ed6bc94d6d207e31f99ae3ed8346683d9"><pre>EVM/Ethereum: missing evm deps</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/29a42d10b2bfaf65d0d937173c4eb87cd6cec038"><pre>EVM/Execution: readapt testing function without basic</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/16aca1ecadf3c29c05f7b635ce6602394e067cfa"><pre>Merge tezos/tezos!8520: CI/EVM: compile independently each subdirectory of kernel_evm</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1d58cf70d3bfb9efabd0795a6fbc76cf110657f5"><pre>Alcotezt: port [src/lib_test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/94e69ee04b14890ecd4dae3b7b5fe3aeb6226f1c"><pre>Merge tezos/tezos!7940: Alcotezt: port [src/lib_test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/435b3d4a3f2c9b8f543071fdba89f9f8f19b59a8"><pre>sequencer: init the project</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/560ad1ca5486aa670604787d8d35682e6102ffba"><pre>sequencer: build the project a makefile</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1f94a4e134bb380fa4cf159143afa6899fb0c5f7"><pre>sequencer: kernel trait definition</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eb8e7e4a6c5513a4b12a3342d2d0f521df2d8143"><pre>Merge tezos/tezos!8517: Initialization of the smart rollup sequencer</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f2c19443e17f0f6e276e006df850238a146263f1"><pre>Alcotezt-UX: fix invocation headers, opt. titles for [lib_client] in all protocols</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/553f19cbfb6fbeb28b6cfc1392e95f10234a09b0"><pre>Alcotezt-UX: fix invocation headers, opt. titles for [lib_dal] in all protocols</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e03a3be4a1b2fc2c9b67324eb80363ab47ba54b9"><pre>Alcotezt-UX: fix invocation headers, opt. titles for [lib_dac_plugin] in all protocols</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/00321bb797709db693322dce048d8e3e3c91d63b"><pre>Alcotezt-UX: fix invocation headers for [lib_delegate] in all protocols</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0d403a7cfaeb3ed6b0a3f75d1caa7a6768fdecb7"><pre>Alcotezt-UX: fix invocation headers, opt. titles for [lib_plugin] in all protocols</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/075e0546f0c43f092cdfecc70c88d5d1f74a8e99"><pre>Alcotezt-UX: fix invocation headers of [lib_base/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4a06b5c245eb017f3435b6007e3e6e921345defc"><pre>Alcotezt-UX: fix invocation headers of [lib_clic/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/23c32c0ef59fde3cb4cb7c67971f3c98633bc207"><pre>Alcotezt-UX: fix invocation headers of [lib_client_base/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ad7c60b17a1a01a61683f262654183b7fbe14a0f"><pre>Alcotezt-UX: fix invocation headers of [lib_client_base_unix/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a880e3eeb3e6b64b403ec1c0575b2c04dbf9750a"><pre>Alcotezt-UX: fix invocation headers of [lib_context/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/16703838b74c01b893ba13efdf4a0d618534a99f"><pre>Alcotezt-UX: fix invocation headers in [lib_dac_node/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7e42b82be943dac7b91f5af297d2626d998ff34c"><pre>Alcotezt-UX: fix invocation headers in [lib_error_monad/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/69b7b3d5566db20fb08606ed929f055da32daf14"><pre>Alcotezt-UX: fix invocation headers in [lib_layer2_store/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/21e2bbd56d85849f67586cac54b2acfff7f9b1b6"><pre>Alcotezt-UX: fix invocation headers in [lib_lazy_containers/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5a648a47a52f269a545c2309165e4c48180451f2"><pre>Alcotezt-UX: fix invocation headers in [lib_lwt_result_stdlib/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b907a55216022c9e7c294408aca9853e90c8c0d6"><pre>Alcotezt-UX: fix invocation headers in [lib_mockup/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e937c6e135c67ec495bca2bbfeebba591ec390aa"><pre>Alcotezt-UX: fix invocation headers in [lib_proxy/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b4ca9b2197480f297785d4ba0ada1627b9edf7eb"><pre>Alcotezt-UX: fix invocation headers in [lib_requester/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fef77296c1d68d86339299fa98b95c4808bcd31d"><pre>Alcotezt-UX: fix invocation headers in [lib_shell/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/41f8b57f1aba0b41886a2234753bc7435f6245c7"><pre>Alcotezt-UX: fix invocation headers in [lib_shell_services/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8b0bf0b585d7d7186cbbf83e3e2e127ba90bbde4"><pre>Alcotezt-UX: fix invocation headers in [lib_signer_backends/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9ba6d4b31247ebd9de0e76758a3ecd645a838059"><pre>Alcotezt-UX: fix invocation headers in [lib_stdlib]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e65a8da10f3eab5053b3eeeafbf97be469a8ee11"><pre>Alcotezt-UX: fix invocation headers in [lib_stdlib_unix]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/736f018204a6cecbb7429717e3d2a4fb0177bb9c"><pre>Alcotezt-UX: fix invocation headers in [lib_tree_encoding/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/040626f59c62ae58dfe7fd3b01341f8a679ed4bc"><pre>Alcotezt-UX: fix invocation headers in [lib_version/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/638d1b2aca5bfd55bc70906ae39dbadac9a27026"><pre>Alcotezt-UX: fix invocation headers in [lib_webassembly]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bc179662e9ebce3a20a435968c2c8dd27fee8666"><pre>Alcotezt-UX: fix invocation headers in [lib_workers]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a18f23b0c357cc3296eccf968edd76b3b59ab0ce"><pre>Alcotezt-UX: fix invocation headers in [lib_rpc_http]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/90a2ba1e7d0d34fe7c3b83fa4e4f639df05d3d8f"><pre>Alcotezt-UX: fix invocation headers in [lib_proxy_server_config]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a93db0d42e2148bb9942ec86743264822e128b5e"><pre>Merge tezos/tezos!8408: Alcotezt-UX: fix invocation headers, opt. titles</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/14fa6fbb180e8e8b445581b50a58cb009f7bea80"><pre>doc: list smart rollup executables in howtouse.rst</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/936ae21abbe3dff722901755eeca82a5cb1e277f"><pre>doc: also mention the wasm debugger</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b0919d849afb94e4b38fdcc7d553913df51e0fc8"><pre>doc/shell: tweak recommendation on Octez versions for snapshots</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7d0f2f2ecd5f433f284c4ff0a8e0d30bd23e1276"><pre>Proto: fix typo [chaind_id]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/07184052729953bf315f2d36bb8cc97013893c97"><pre>doc: improvements to user/logging from !7849 reverted by !8478</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e6653ed3a6fcd4323cf86686b6693d51e31a07ae"><pre>doc: fix backticks in releases/version-17</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d92d23d402a2be9e996d8e29c0c0cfc281592be1"><pre>doc: tell that executables in the_big_picture are a subset</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/edbf5977d95d8058b4f12210558b4de7adc5d99f"><pre>doc: fix link to rpc-openapi-beta</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b79208edc4faa2d8162401bc5616b9cc916a7f96"><pre>doc: fix broke link to FA12 implementation in Archetype</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4a4ee863a40439e574f237beefaede7a700b4c82"><pre>Merge tezos/tezos!8412: Typo doc</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0f1a22765e865bd25b71276beb20543eedf7bdd5"><pre>proto/soru: new_address fct for origination</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/178877132fb50668f929c846f1307dc7ff7875b5"><pre>proto/soru: split origination fct to ease readability</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dcf934dd8889ca08dfac1545cd646a08982abf65"><pre>proto/soru: add todo for origination cost</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cbcdda5f21b64bd14a965b134638fc8c2569db7b"><pre>doc: add change line for soru origination function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3dbfa1a47fe1d7b7d67bcffc9fb2a9926091b56b"><pre>Merge tezos/tezos!8276: smart rollup: split smart rolllup origination fct</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/66299c226ae217abdb452d690e8252108601d3c9"><pre>P2P/Test: Simplifying overenginered code</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/76616dda206d697a271f34dfa210281077909528"><pre>P2P/Test: IO scheduler fix port generation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/957ad28a2f6396ce0aa1d7392572a4e5cd819ecb"><pre>P2P/Test: do not close the socket in [gen_points]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/115eb79a478a33b8288ebe0a74586310f5d817bd"><pre>P2P/Test: Fix point registration in P2P pool tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1dcb5977228831b167421b44afae7d5464161e94"><pre>P2P/Test: Remove unused \`gen_points_interval\`</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bc191142dc5fbe3e5cdf653b457a8b1196373806"><pre>P2P/Test: Inline \'gen_points\' function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/17b6d8f1fcc8bc8b0f58f8a1347309e6af11ac03"><pre>P2P/Test: Fix point registration in P2P broadcast</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/71530b902edd2b4c8e814e26653c8605850debd3"><pre>Merge tezos/tezos!8319: P2p: do not close the socket in [gen_points]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/348d8dcaee3d88d9af0790d8f4e795b1bae5978d"><pre>env: bootstrap environment V10</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cd3a4d6a41e82d1c81f21a2d10f13990ade8951e"><pre>proto: use environment V10</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4a547ff8a56e38adeb432be43708b767de67bdb6"><pre>doc: add entry for environment v10</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/50fb7e4055d6112d264be003a2783bb8e0166e50"><pre>Merge tezos/tezos!8528: Env: Bootstrap environment V10</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d9a88a34b9a9f161cb2383fdf8f044f590aa1be6"><pre>Tezt: run regression tests on Nairobi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5b503c4ab63dc633ad9a215905b9153f7c0eae91"><pre>Merge tezos/tezos!8545: Tezt: run regression tests on Nairobi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/654d1b265c5d8c2a60aebcd4cd5693995b22e19a"><pre>Lib_context: allow context binary creation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e7497fae2e6fd2e38f345bcbca68e55c1e160b18"><pre>Merge tezos/tezos!8550: Lib_context: factorize context binary creation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/69a06e71d49099ff3b36a13d03bfd3b9afd63cf3"><pre>Logs: add config rules parser</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/521866f52e4e18229e8abca3873c3d29d11fd03c"><pre>Tests: add tests on log rules</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5505c6ec704101effe2eb1d41d4f548b8e81d780"><pre>Merge tezos/tezos!8178: Logs: reimplement config rules parser (lwt-log deprecation)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/39dd704ce1b8421892a796847bfc54358e61c3e3"><pre>Lib_crawler: monadic map for reorg structure</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c1445098d0d3547e5b17747f261323dad53f818d"><pre>SCORU/Node: use block headers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/04d131dd7051b50aeb7e0469dec9cfa2f81f9bbe"><pre>SCORU/Node/016: use block headers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/56033664f85a55c736361ad47467c168ffeaec70"><pre>SCORU/Node/017: use block headers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/711e33e355542936bcf61afd23ca84ecad2a02ba"><pre>Injector: only need shell header</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4da49c573f8e57d727cf4fc3daa7153e714fb431"><pre>SCORU/Node: preemptively cache block headers when monitoring</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4afafd00786a8632604363a3c05ca95953067e9d"><pre>Merge tezos/tezos!8482: SCORU/Node: Use tezos block header when monitoring L1 chain</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2c36123b96fbaa66b02713bd96db1380ccc3c3f0"><pre>Kernel SDK: allow publish to crates.io</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3de0b3bac260a935266c43def12d1da0fbed03ef"><pre>Merge tezos/tezos!8525: Publish Kernel SDK to crates.io</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5c9f1e2bb256d51a7b7cdef6efb833c73ab4546e"><pre>P2P/Test: Remove \`test_p2p_logging\`</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2e760b4b200ad111ca3f60ed6fa072466159573e"><pre>Manifest: Clear comment related to 1184</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1422c29fea3e807b11ebd10381f102891a07dd07"><pre>Merge tezos/tezos!8549: P2P: Remove a test about P2P events</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/83f41e93515428212d620c6b2bcdbb4a2209d9e1"><pre>Internal_event_config: internally build a log URI in a typed fashion</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/46358264fbedbd3c0a7603eba5cfe49647051b92"><pre>Merge tezos/tezos!8177: Internal_event_config: internally build a log URI in a typed fashion</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1bdb99508894c8cd313793ea597d0f0ab9214287"><pre>SORU: add debug to bench command in debugger</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9e68145db8b4dfccac84f6db322da10002a218e6"><pre>Merge tezos/tezos!8454: SORU: add debug to bench command in debugger</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8b65cfbd3fc0219ea101cc9de895fe804fbd1187"><pre>Gossipsub: P2 scoring</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ce1bb9593c58e1aa0e9a24b1b29e1c4988fe6d14"><pre>Merge tezos/tezos!8464: Gossipsub: P2 score (first message deliveries)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8583b35feeafad1bfa0e3c8b9c0ab7aafa9699d9"><pre>manifest: introduce <proto>.lifted library</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f7e6d0dd3d7db1c61db8cdce133570da04a580d0"><pre>manifest: lib_client depends on <proto>.lifted</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4436cabd2aabbeac3871ea5ac1f3a2888ce95181"><pre>proto/lib_client: use lifted protocol for block_services</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/47b1f0fa71f725324cfc4d7288e053e3c6972892"><pre>alpha: open and use lifted protocol when necessary</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0df8ffda9473cd61f54f945da99b6f376bc9f933"><pre>Merge tezos/tezos!8529: manifest: add <proto>.lifted library</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0822b6357be15d233e8e2759fca73b3e0aafa133"><pre>Gossipsub/Test: Expose Message_cache module for testing</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8dd8e8672ff1018cffcdf9173055a5a6d89a53d1"><pre>Gossipsub: Add tests for Message_cache</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/700920f90da81d5f11e4bc2a681f29523bc57a67"><pre>Gossipsub: Stop using Introspection module in message cache PBT</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8717ed1ea60ead53618714930e61cf6e0fe6df65"><pre>Merge tezos/tezos!8514: Gossipsub: Add tests for message cache</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/099d404ea774baccff64e59d55ae4cce9a6304f7"><pre>soru/tezt: publish and cement is robust over migration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dcafbe319f3f4fcd84d105ebf98ec3be8eeeed78"><pre>Merge tezos/tezos!8255: smart rollup: add test for commitment (publish and cement operation)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/52d6dee841046727b59bd18661051cdb59513fc8"><pre>Kernel SDK: fix SSL error in CI</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6cd132a6a14fd9aeaa2c9f0ddf7c08dd98a138a3"><pre>Kernel SDK: set intra-workspace dependency versions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c2e3162e9012c27931050a7cbbaf62116ea21235"><pre>Merge tezos/tezos!8560: Kernel SDK: fix publish in CI</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fce5e09b4bb541ba006ba4bd163cba767ff52112"><pre>Proto: Migrate from Nairobi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/810caf46bbb0d4c4fefce87d09bb75d462954620"><pre>Proto: Update previous constants representation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3bcba87789de191562340c5ff8322aa7b2567bcd"><pre>Test/Tezt: Migrate from Mumbai</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dc022e0de350c5d3daa17483a950e3c5de644afc"><pre>Merge tezos/tezos!8349: Proto: Migration from Nairobi to Alpha</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/98e877bf3737407d201c3e1cd09849cfc14c83e3"><pre>Shell/RPC: allow to monitor heads only of the current protocol</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/39ff3d991101eb34e38682891b9c26bff4cf8a32"><pre>Doc: changelog</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fa83a2b413ab05f0586c58b9b24cea43db29913a"><pre>Merge tezos/tezos!8448: Shell/RPC: allow to monitor heads only of the current protocol</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/912f9bf6e29b0c45b3b0967d6318addbbf524a1b"><pre>Tezt: remove TORU tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/378124b5e8e7650e7f9da02e883aa14c2f862af7"><pre>Tezt: Remove even more TX related stuff</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1aa21e49baac3f2818adb9a54596d043dbf32106"><pre>Tezt: add tz4 to regressions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f8cf9f252990caa2f2d366564ce9e8d29724bafc"><pre>Merge tezos/tezos!7369: Tezt: remove TORU tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a3fb1a91beabb86f64dd401347c9b2dba20568e5"><pre>Crypto: smart rollup address as primitive hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2a22661feda4bfaf90ea701cda3acc7da0ab0fed"><pre>Environment: expose smart rollup address</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5eadeabd38ff914c0bb93a1689f2ed9e36f2fd60"><pre>Proto/SCORU: use environment smart rollup address</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c420fc7d3b59e287ca1978d34c944503d5a5bb9e"><pre>Merge tezos/tezos!8562: Environment: introduce smart rollup address</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/9b10efc7bc146cd39f5565c1f2179ae8c3ee57ea...c420fc7d3b59e287ca1978d34c944503d5a5bb9e