### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1682526928,
-        "narHash": "sha256-2cKh4O6t1rQ8Ok+v16URynmb0rV7oZPEbXkU0owNLQs=",
+        "lastModified": 1682786779,
+        "narHash": "sha256-m7QFzPS/CE8hbkbIVK4UStihAQMtczr0vSpOgETOM1g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6b863fd9b7bb962e6f9fdf292419a775e772891",
+        "rev": "08e4dc3a907a6dfec8bb3bbf1540d8abbffea22b",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1682618097,
-        "narHash": "sha256-a5cXmaXRLAP95Uu5ilhvwNPg97Lls14wpWoes+kbQ1g=",
+        "lastModified": 1682691100,
+        "narHash": "sha256-w7mfE3OcWMXBUgMGegkHp4KL//2Pex6PkctoGrBmUFQ=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "4a89056e49877f33e27df9d97054b597c7aed4f3",
+        "rev": "8b74239d74c767d117f02cde027a653f42a1d617",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230428";
+    octez_version = "20230501";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/e396c219fd1438f02384b9d73b318fd39fd2fd08"><pre>Scoru,Node: optionally use boot sector from a file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/39557d8b9ea7fdc90f44d4e27a5689b2ca8ef9a9"><pre>Scoru,Node: assert genesis commitment is equal to L1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5625b69ae476a2ac4fd7c67e8cce2c38f2929670"><pre>Scoru,Tezt: test argument boot sector file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/10641b095e7766fed7967961f7639966187c7c4b"><pre>Merge tezos/tezos!8556: Scoru,Node: optionally use boot sector from a file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/356c6ae097cfdff4418d35ae44c0e733f5cb19f8"><pre>EVM/Kernel: extend debug msg log when reading current block is failing</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c6ccd8fff2b0d667e2679da8c1f14a4365ab57d2"><pre>EVM/Kernel: add a \'read_store_empty_safe\' function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f6be2e1f8b26f9bb663ba4bd18c82520d36223e0"><pre>Merge tezos/tezos!8576: EVM/Kernel: fix RuntimeError related to transaction hash reading from a block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b6fd43e1d1b69f712bc489c9702a63ed9f6bdd71"><pre>DAC: add Dac_plugin.raw_hash type in the APIs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eca35bab914b9d0971115499efa471d81314736d"><pre>DAC: renaming and rework page_store</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2207de65fbead7894595f71afd9d1f5721e3ec9d"><pre>DAC: rebasing and modify streaming endpoints</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e78277bfb8ea7cd17139629f78e322ac8093c36c"><pre>DAC: using raw_hash in streamers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ca46dc99ba6d8ca78da16b47c0b8e3072aa191f0"><pre>DAC: rework using of dac_plugin</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/14ea60d8f84a0e72ab2dcdd18cce0734cd871055"><pre>DAC: unsafe conversion return tzresult</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/53eb5ab9dc2c44e05741c52415ae1379b2a34502"><pre>DAC: rework unsafe conversion + error type</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3c70e89c43832e80ec67d275417f1f32e937fb15"><pre>DAC: rework error type + switch back to hash in external_message</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fee480fa380f1042b7d1a4b06c18566e5d5e5b91"><pre>DAC: fix docstring comments</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/10d5b4688d69bb1ea40a4acf8b97627d95ed24f7"><pre>DAC: define raw_to_hash inside dac_plugin.ml</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0281e1d01d0319b6c8e538da7b5c4f0cdae47af4"><pre>Merge tezos/tezos!8496: DAC: add Dac_plugin.raw_hash type in the APIs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c1f33c8f31bae98e78765bfe7f651974e714f085"><pre>Ddb: do not mutate requests table while iterating</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c87f67f2860c42532e60a88498dd1ffd6a6bbe27"><pre>Ddb: compute the minimal timeout while folding on requests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c59f97d34b39ae5f699c68714b4006dc6a315e84"><pre>Ddb: implement request batching by adding explicit throttling</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f401e499df7c75be641f88d948d3638730591d74"><pre>Ddb/Tests: adapt tests to the new throttling mechanism</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/45493fb976e6b1ca1c1e2d3fe16b0400ebaac96b"><pre>Changes: added an entry</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4ef3de8ab574064be653fa01c5f9456daba5992d"><pre>Merge tezos/tezos!8503: Prevent the DDB from freezing the node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/24eea4bace4b2f151e4a48dc04d794272d7d55b5"><pre>Nix: Bring in llvm-ar</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7d38f1a4c140765172ec0349ef3b89fbb76cdb01"><pre>Merge tezos/tezos!8578: Misc Kernel development environment additions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b7221fa6d19ac1077982bdba35d5677899f319c2"><pre>Octez/Node: refactor Node_identity_file to break dep to Data_version</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/72e17b2657bbc1b617640d26d2371688355f59e1"><pre>Manifest: perpare a new lib in src/lib_p2p_identity</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2d212d888104843170d92ead9194d5dddb8b54ca"><pre>Octez/Node: move node_identity_file* to lib_base/p2p_identity_file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e1fb4dd3ab1f2dc436150684dc5a6fe508097cb4"><pre>Node: move function init_identity_file to lib p2p_identity_file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1371cb40ad59f6d77b9a919965ff1890b054bd5f"><pre>p2p_identity_file: add comments in interface file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e999b51d3297ce7d2901f3e4a2dae482d5b542a9"><pre>Merge tezos/tezos!8590: P2p identity: refactoring to use the code in DAL node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/85b5b4f05c6ce0265fce6fd8531532dfbfbfe0f1"><pre>doc: add hints on using docstrings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8b74239d74c767d117f02cde027a653f42a1d617"><pre>Merge tezos/tezos!8071: doc: add hints on using docstrings</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/4a89056e49877f33e27df9d97054b597c7aed4f3...8b74239d74c767d117f02cde027a653f42a1d617