### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1682879489,
-        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "lastModified": 1683014792,
+        "narHash": "sha256-6Va9iVtmmsw4raBc3QKvQT2KT/NGRWlvUlJj46zN8B8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "rev": "1a411f23ba299db155a5b45d5e145b85a7aafc42",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1682936445,
-        "narHash": "sha256-trjgAY12k5gWKM8JFz/pB6dFGJmt2BF59ClfZSGeNcA=",
+        "lastModified": 1683176385,
+        "narHash": "sha256-J/P6C6sobyabRN20/RgruIp6rK3A9cwLaB1pLlpn/qM=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "19e993fe1ffd4284655789adaca22e7758cabf9f",
+        "rev": "15a4a4503cafc257685e296e517b59be1e925a86",
         "type": "gitlab"
       },
       "original": {
@@ -276,11 +276,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682536470,
-        "narHash": "sha256-dGR2FRxWswpQCHdivejB3uiLZPktnT3DYp6ZkybR/SE=",
+        "lastModified": 1683117219,
+        "narHash": "sha256-IyNRNRxw0slA3VQySVA7QPXHMOxlbx0ePWvj9oln+Wk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6d8bea2820630576ad8c3a3bde2c95c38bcc471f",
+        "rev": "c8c3731dc404f837f38f89c2c5ffc2afc02e249d",
         "type": "github"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230502";
+    octez_version = "20230504";
     src = inputs.tezos_trunk;
   };
 in {

--- a/nix/trunk/overlays.nix
+++ b/nix/trunk/overlays.nix
@@ -59,6 +59,14 @@ final: prev: {
             checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
           });
 
+          tezos-micheline-rewriting = osuper.tezos-micheline-rewriting.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-proxy-server-config = osuper.tezos-proxy-server-config.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
           tezos-stdlib-unix = osuper.tezos-stdlib-unix.overrideAttrs (o: rec {
             checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt oself.tezos-test-helpers ];
           });

--- a/nix/trunk/overlays.nix
+++ b/nix/trunk/overlays.nix
@@ -1,11 +1,63 @@
 final: prev: {
   ocaml-ng =
     builtins.mapAttrs
-    (ocamlVersion: curr_ocaml:
-      curr_ocaml.overrideScope' (oself: osuper: {
-        tezos-event-logging-test-helpers = osuper.tezos-event-logging-test-helpers.overrideAttrs (o: rec {
-          propagatedBuildInputs = o.propagatedBuildInputs ++ [oself.octez-alcotezt];
-        });
-      }))
-    prev.ocaml-ng;
+      (ocamlVersion: curr_ocaml:
+        curr_ocaml.overrideScope' (oself: osuper: {
+          tezos-event-logging-test-helpers = osuper.tezos-event-logging-test-helpers.overrideAttrs (o: rec {
+            propagatedBuildInputs = o.propagatedBuildInputs ++ [ oself.octez-alcotezt ];
+          });
+
+          tezos-lwt-result-stdlib = osuper.tezos-lwt-result-stdlib.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-error-monad = osuper.tezos-error-monad.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-hacl = osuper.tezos-hacl.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-clic = osuper.tezos-clic.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-signer-backends = osuper.tezos-signer-backends.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-client-base = osuper.tezos-client-base.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-protocol-environment = osuper.tezos-protocol-environment.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-context = osuper.tezos-context.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-version = osuper.tezos-version.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-crypto-dal = osuper.tezos-crypto-dal.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-shell-services = osuper.tezos-shell-services.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-webassembly-interpreter = osuper.tezos-webassembly-interpreter.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
+          tezos-stdlib-unix = osuper.tezos-stdlib-unix.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt oself.tezos-test-helpers ];
+          });
+        }))
+      prev.ocaml-ng;
 }

--- a/nix/trunk/overlays.nix
+++ b/nix/trunk/overlays.nix
@@ -1,75 +1,75 @@
 final: prev: {
   ocaml-ng =
     builtins.mapAttrs
-      (ocamlVersion: curr_ocaml:
-        curr_ocaml.overrideScope' (oself: osuper: {
-          tezos-event-logging-test-helpers = osuper.tezos-event-logging-test-helpers.overrideAttrs (o: rec {
-            propagatedBuildInputs = o.propagatedBuildInputs ++ [ oself.octez-alcotezt ];
-          });
+    (ocamlVersion: curr_ocaml:
+      curr_ocaml.overrideScope' (oself: osuper: {
+        tezos-event-logging-test-helpers = osuper.tezos-event-logging-test-helpers.overrideAttrs (o: rec {
+          propagatedBuildInputs = o.propagatedBuildInputs ++ [oself.octez-alcotezt];
+        });
 
-          tezos-lwt-result-stdlib = osuper.tezos-lwt-result-stdlib.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-lwt-result-stdlib = osuper.tezos-lwt-result-stdlib.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-error-monad = osuper.tezos-error-monad.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-error-monad = osuper.tezos-error-monad.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-hacl = osuper.tezos-hacl.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-hacl = osuper.tezos-hacl.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-clic = osuper.tezos-clic.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-clic = osuper.tezos-clic.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-signer-backends = osuper.tezos-signer-backends.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-signer-backends = osuper.tezos-signer-backends.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-client-base = osuper.tezos-client-base.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-client-base = osuper.tezos-client-base.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-protocol-environment = osuper.tezos-protocol-environment.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-protocol-environment = osuper.tezos-protocol-environment.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-context = osuper.tezos-context.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-context = osuper.tezos-context.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-version = osuper.tezos-version.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-version = osuper.tezos-version.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-crypto-dal = osuper.tezos-crypto-dal.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-crypto-dal = osuper.tezos-crypto-dal.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-shell-services = osuper.tezos-shell-services.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-shell-services = osuper.tezos-shell-services.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-webassembly-interpreter = osuper.tezos-webassembly-interpreter.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-webassembly-interpreter = osuper.tezos-webassembly-interpreter.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-layer2-store = osuper.tezos-layer2-store.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-layer2-store = osuper.tezos-layer2-store.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-micheline-rewriting = osuper.tezos-micheline-rewriting.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-micheline-rewriting = osuper.tezos-micheline-rewriting.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-proxy-server-config = osuper.tezos-proxy-server-config.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
-          });
+        tezos-proxy-server-config = osuper.tezos-proxy-server-config.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt];
+        });
 
-          tezos-stdlib-unix = osuper.tezos-stdlib-unix.overrideAttrs (o: rec {
-            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt oself.tezos-test-helpers ];
-          });
-        }))
-      prev.ocaml-ng;
+        tezos-stdlib-unix = osuper.tezos-stdlib-unix.overrideAttrs (o: rec {
+          checkInputs = o.checkInputs ++ [oself.tezt oself.octez-alcotezt oself.tezos-test-helpers];
+        });
+      }))
+    prev.ocaml-ng;
 }

--- a/nix/trunk/overlays.nix
+++ b/nix/trunk/overlays.nix
@@ -55,6 +55,10 @@ final: prev: {
             checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
           });
 
+          tezos-layer2-store = osuper.tezos-layer2-store.overrideAttrs (o: rec {
+            checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt ];
+          });
+
           tezos-stdlib-unix = osuper.tezos-stdlib-unix.overrideAttrs (o: rec {
             checkInputs = o.checkInputs ++ [ oself.tezt oself.octez-alcotezt oself.tezos-test-helpers ];
           });


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/f31f487c42594e88e24e74d6d2101fb0bba85a73"><pre>Gossipsub/Test: Fix error messages</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4c287e2c11f3d4beb09d6fa006cc0ddd094c2198"><pre>Gossipsub: Factor out sliding message id map from message cache</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/aebef2bd5a324991bdacb09daed5bb2c17f6ab04"><pre>Gossipsub: Implement seen message cache in Message_cache</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1749eeeb40f3e064fbe213c445e8f1c0253ca80e"><pre>Gossipsub: Switch to use seen message cache in Message_cache</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0f402a456e8b9c3b6d886ec51c0c8e819bd58177"><pre>Merge tezos/tezos!8572: Gossipsub: Introduce TTL for seen messages</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7e31574bc1a32d5ff9593f66fa4de693d2f4a94c"><pre>SDK: implement trait Error and Display for PathError</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1a987328a88dd2fb7e384d9416220f0b0043b5a9"><pre>Merge tezos/tezos!8589: SDK: implement trait Error and Display for PathError</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2b4a309d5fddc23a5339106251dd74aa22bb85dd"><pre>Gossipsub: add [validity] predicate to messages</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/54ee7b59c244ebde754cc07eda2ae0893d5d26f5"><pre>Gossipsub/score: P4 score computation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/61b349a0748f2aa154b5d7910bf1970c17231c03"><pre>Merge tezos/tezos!8542: Gossipsub: p4 score computation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bd9b3e43781f7e6d9bb67ab2df4550ee4566b05e"><pre>Gossipsub: p5 score functionality</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/017488f9a7922c51ea40e638b089e2e38d758396"><pre>Gossipsub: set_application_score message</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9a6126501a788348a3de972078eac624887e4ac3"><pre>Merge tezos/tezos!8568: Gossipsub/score: p5</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/98d4fba12d6456e596b0d8cabe16a09dca123f91"><pre>CI: remove job [unit:lib-store-unix]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/109135e1322c166769336c40687a6f1c2975a39a"><pre>Manifest: Add [enabled_if] to [test] and [tests]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6b2bd8db677bfd553eb6e07282bd908e9a9f8647"><pre>Manifest: tezts use [runtest] disabled in the CI</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cb5434271db7396f3e82a7c671d3ff1617f7d5ff"><pre>Manifest: update opam/dune files</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6a20fc07ae25e77d6605feeb740b933177c19562"><pre>CI: deactivate Tezts in unit jobs but run them in opam jobs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/19d063f655eea758927a20ea5f0b78936ea63cef"><pre>Makefile: Do not run [runtezt_js] in [test-js]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5a436d5c13d6d545a43d9f817f56b0f5c24edb1d"><pre>Docs: Replace mentions of [runtezt] with [runtest]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2521a8696cc8a6a8a5b293bea02457d30965472e"><pre>Merge tezos/tezos!8502: Alcotezt: merge [@runtezt] into [@runtest]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4194390102f1f11aab225b599194c97479d8ae24"><pre>Gossipsub: add decay-related parameters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/81491b99a7c51b6fde0840ca879344cfb13c07d8"><pre>Gossipsub/score: switch counters subject to decay to float</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/81ae9f47082b03f22bf6ea65ce92c1b3f88a6ed3"><pre>Gossipsub/score: decay</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a8a8915eb71bdc3909d9e9c318195ba2a7fb7b24"><pre>Merge tezos/tezos!8570: Gossipsub/score: decay</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/be619e662e7b7c9efc76d0bfe0fc561abea08fc9"><pre>Env: remove List.*assq functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7bcb1982d41d3bf5e755c624b2a9ceb0b68fc628"><pre>Merge tezos/tezos!8507: Env: remove List.*assq functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/749b585abda7ba707ac48526324aacc1495c71c8"><pre>Proto: Fixed incorrect comment</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/231d770c4b855ad2b87067a604cd109b46aa2f71"><pre>Merge tezos/tezos!8622: Proto: Fix incorrect comment</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a38577499f200615a2cbb87f6110acf53b62dfd1"><pre>SORU: EVM: make signature verification safe</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9e301f2f4d63905cd41a195a79e47dbc17973ced"><pre>SORU: EVM: cleanup tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/78fcc90c528697a4f8081e59f164047539676125"><pre>SORU: EVM: add U256 overflow checks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8e2cbcffe9682afda8d0ba40314ad8d54a325a9e"><pre>SORU: EVM: more info to error</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dab4ec301d16336f2d33bbed0f0783b310982799"><pre>Merge tezos/tezos!8473: SORU: EVM: make signature operations safe</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9bd5b0ef361f321c44c29af9ffdadcbb65a84281"><pre>Gossipsub: add optional topic score cap</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c7fd9e9d0e000e6b4e3332f4ee298b79dd0bc866"><pre>Merge tezos/tezos!8583: Gossipsub: optional topic score cap</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/83289dff387b76ae57702061d5b1a38893a99bb6"><pre>EVM/Kernel: Move L2Block/BlocksConstants from kernel/evm-exec in tezos_ethereum</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/83af6c8f8dc2f21791171e4528997bb2c5c49d14"><pre>Merge tezos/tezos!8551: EVM/Kernel: Unify block\'s representation between evm-execution and evm-kernel</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a03ea8fa09f7dcdd248defe15851fc9b078388e7"><pre>SCORU/Node: Compute genesis commitment instead of fetching with RPC</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cf4b57923082852f29bfe8a2ee36b09d18e96f52"><pre>SCORU/Node: backport !8617 to Mumbai rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0c980b7a39ba457d2b7775ba003bdaf272ae99a3"><pre>SCORU/Node: backport !8617 to Nairobi rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9583b077d2a7f55a1d8ff5634bddffcf0682c295"><pre>Merge tezos/tezos!8617: SCORU/Node: Compute genesis commitment instead of fetching with RPC</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8fa244de7810bfb2d4c143cfd84d6a709ffdb602"><pre>Build: Improve Makefile rules related to kernels</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2479a80ff808f118a991a55b0021c42d8feb7d6a"><pre>Merge tezos/tezos!8479: Build: Improve Makefile rules related to kernels</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d726c39e52bc8be2fa6910410111c15ea0d96edb"><pre>WASM PVM: Let the CI enforce that the hashes traces of V0 do not change</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dad969a52b5a31b1dfb393bdc69774db4c9cf14c"><pre>Merge tezos/tezos!8463: WASM PVM: Let the CI enforce that the hashes traces of V0 do not change</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/09ca517c7c7837366e8d20738aeb752984271d11"><pre>SCORU/Node: rely on cementation metadata for commitment</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1fbd43cec7e432b807a636f2aaff54e0992e12be"><pre>Test: ensure rollup node ignores cementation commitment hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/387e98d711a83c401d37aeb559c347676d14f16c"><pre>Merge tezos/tezos!8615: SCORU/Node: rely on cementation metadata for commitment</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c0ea0998d6803b567554fb05d7effd95b876388b"><pre>Kernel SDK: avoid overwriting CC</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2afe0ba6ede598d9e464c5083607b03f2abfa048"><pre>Kernel SDK: extend README with wabt instructions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7371badef82b9d108156bd56211ad5f68bcdeb5a"><pre>Merge tezos/tezos!8623: Kernel SDK: Address build issues on Mac</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a2e38ec593292820c079913fa9b3bf56ff5221fb"><pre>Docs: remove endorser note</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0abee3afcd1f8f7be3428141b36fe152d6196b42"><pre>Merge tezos/tezos!8532: Docs: remove endorser note</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6806eca95c4a5be17497dbc650056cdaba9e34f3"><pre>EVM/Kernel: use evm-execution.run_transaction</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5d8e048078aa4f45e27e2c20d04ceb2cd8d9d775"><pre>EVM/Kernel: rely on evm execution\'s account storage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1e71e546d6f367e2845d10d585bd4aa234f76071"><pre>EVM/Kernel: test to check mint accounts balances</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b5a1db130571e7896edd7e6b880423604b59c51f"><pre>EVM/Kernel: test if a valid transaction produces a valid receipt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7d961cbbec7b546cebc89aa24f24971ca21424e9"><pre>EVM/Execution: store accounts values as little endian</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8c595a04732d33f4de0801023ea399e0258f7b5f"><pre>EVM/Kernel: test several transactions validity</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f76e13f9d5845000a62afdb16222fa36382c20da"><pre>EVM/Kernel: test several proposals validity</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a5f4f59720b78dc4a447e5d6354022e0b110d041"><pre>EVM/Kernel: store/read receipt\'s cumulative gas used</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/303358963abf01f2b5798d8384723f9fda7545bf"><pre>EVM/Kernel: test transfers gas consumption consistency</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ba790f6ed3538ef92d33fbada0fbdc233aed0b74"><pre>Merge tezos/tezos!8559: EVM/Kernel: plug evm-execution\'s run_transaction to the kernel</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/39d9c58faf18f3f56f1b4c907f7e78018cd45d32"><pre>Lib_bls12_381_signature/tests: fix tests declaration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/537890913c70535beacfa66f2078e4dc557d90f2"><pre>Merge tezos/tezos!8611: Lib_bls12_381_signature/tests: fix tests declaration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/657a821e0279cba4bca112c74c0014587722cbbd"><pre>WASM/Helpers: fix \`eval_to_result\` yielding on reveal unnecessarily</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6e4b7c8202ac6bdeb19a56df5bc2a1f54484d6b7"><pre>Merge tezos/tezos!8628: WASM/Helpers: fix \`eval_to_result\` yielding on reveal unnecessarily</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fcf113ea164086980067ddb608b2be19517b2968"><pre>Makefile: remove target [test-lib-store-unit]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/88ca3b3ee7aa87805ef1da906d60eade32f6c405"><pre>CI: Bring back [unit:proto-x86_64] job</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/735bbe2b82277d54753a39622cc906efc4ba3332"><pre>Merge tezos/tezos!8421: CI: Activate accidentally deactivated inline tests for protocols</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fc8648e184d060510981e21f36934e333f6a3d4e"><pre>DAL/crypto: remove polymorphic equality and comparison</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/75861b5ba1d3ed9d22bf99e1aff8628651ab9d8d"><pre>Merge tezos/tezos!8624: DAL/crypto: remove polymorphic equality</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/246658639629540e56c6fe2606acd831e48ebe45"><pre>Node: add new entry TF bootstrap nodes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/64a364176ea070d8e9a6a61caf71392767a781ec"><pre>Merge tezos/tezos!8593: Node: add new entry TF bootstrap nodes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/83408a935b14a51f0fd2374858f45096e321a476"><pre>Proto/Michelson: add the UNIT instruction to the IR</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/959caf0f9a2c81042d7f7216a9dc6d9e212c7a7e"><pre>Changes: mention MR !8579</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/145d8a30e71a94b5694baa70294d5cd708888131"><pre>Proto/Michelson: Improve the size model for UNIT</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1bf676b39fa0c3433322000a5c3dba31fb9f711f"><pre>Tezt: update regression traces</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/29c5c982ad0d52e7688c43a3a463b476972eb331"><pre>Plugin/Michelson: fix UNIT case in pp_instr_name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8668aba3a265175496329e047a7339f71b1f17ba"><pre>Tezts/Proto: Reset regression traces</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/01bd42a8abaf7d74d7e4592a419c7cc018b8024b"><pre>Merge tezos/tezos!8579: Proto/Michelson: add the UNIT instruction to the IR</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d14017f10249d1f381749281b7e6a3be0ca6ef86"><pre>DAL/GS: be able to handle milliseconds in Span</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c36c3ed13eb5b81492a6da5531cc85d7874c143d"><pre>Merge tezos/tezos!8630: DAL/GS: be able to handle milliseconds in Span</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cc7a235d6f0248b74ca5c93e7298254bf8cca823"><pre>Everywhere: replace list emptiness tests with pattern-matchings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/03796107b775a4036e89a0d7574253e317a1c9d2"><pre>BLS12_381 polynomial: avoid recomputing length of evaluation lists</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f9b89df5dab98f33392f4f7a1c4836745277a469"><pre>Epoxy: improve readability of a non-emptyness assertion</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/70d77364c800d0a0f0d1e40608f8d2b75263d424"><pre>Semgrep: add some rules about list emptiness tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7fe8f3f697ee9cbe2e8eff5d1345e5ce74f4bf55"><pre>Merge tezos/tezos!8457: Add semgrep rules for list emptiness tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d1d75e2a7bdfc2ca8c664e646835feb9a6ad2246"><pre>Dac/Daemon: remove unused function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/90d4b54f4d02fbbed9de4327b9d3bbbb5e7dfee5"><pre>Dac/RPC server: improve signature for directory registration functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c24314ec8f584db06f1c4b3b27b9eba01d5b78f5"><pre>Dac/Signature manager: move errors out of Coordinator module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/219ad220f3fee2d7a0b2d1a771ada18016a9d91f"><pre>Dac/Node context: retrieve committee members by operating mode</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b52522e0506a9dfdcb3e1d567ee8a8144309c8ba"><pre>Dac node/Rpc server: operating mode specific signature update registration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/21902200d46687070a76ec95deced07af1034793"><pre>Dac/Signature manager: improve state of modules</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/51db3e0d5857900787d298fd4b8f4104098f0f0f"><pre>Dac Node/Rpc Server: Improve type safety</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ee200b94fc09a65662cd7b997e963fd6265b4c13"><pre>Dac/Node: consistent naming for operating modes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f40117b830891555f58b95279416584c0c4c4508"><pre>Dac Node/Node context: remove type unsafe functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2804d7df155825dc96e30eb1f361208eb1544037"><pre>Merge tezos/tezos!8032: DAC: Improve type safety of RPC server</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4fc149f2c524ba29aed480d35c6c24329f9bbdac"><pre>EVM/Kernel: extract check/test of reading current block after stage_two</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/52f8307811fc7dd448f6cf955b08becbab7fb665"><pre>EVM/Kernel: add more verbosity for debugging when reading/storing current block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6363054d5ecb40522d5607779de49f8e1d17cbe9"><pre>Merge tezos/tezos!8632: EVM/Kernel: extract check/test of reading current block after stage_two</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2100d8b5129bb0c9a104bcf35b69ad296b9b0d99"><pre>Build: use ALL_EXECUTABLES in the clean target</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2c241fe12e3e35130f89bd69b0c60ed33895bca9"><pre>Merge tezos/tezos!8603: Build: use ALL_EXECUTABLES in the clean target</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b371a677843df35e0b6273014f1ed44168e3a533"><pre>lib_scoru_wasm/test: port tests to alcotezt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/edf673670d3f3a135c6da2ad510bc825cc915ffb"><pre>lib_scoru_wasm/test: use [alcotest-qcheck]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/11f92be5ebc7d75b1b41f5d8390e468c6aa83c8b"><pre>scripts/version.sh: update [(full_)opam_repository_tag]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dd2d4fc38065e49209ed9a770955ca9608e2568d"><pre>Merge tezos/tezos!7988: lib_scoru_wasm: port tests to alcotezt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d343001500c038eb34d1ada89238ddb0d27b8c15"><pre>Shell: fix incoherent fetching_step message</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/778279b14ec00515993f9e952fea43a870e0564a"><pre>Merge tezos/tezos!8639: Fix incoherent fetching_step event</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b87185384c94d19899cd59073106e47897995406"><pre>Kernel SDK: Add binary config instructions with encodings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/49fd474b791e1ad75ae6e09b0334c1a0dddc5838"><pre>Merge tezos/tezos!8324: Kernel SDK: Support installer config. Part 1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d8847b7e2c7f1b04e8e56bf29f57b44b60a90578"><pre>Gossipsub: Split message publish and routing</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/22bc93e1e8f5523cbbbe325d1a9792dea5b0571e"><pre>Gossipsub/Test: Add tests for handle_receive_message</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/15a4a4503cafc257685e296e517b59be1e925a86"><pre>Merge tezos/tezos!8613: Gossipsub: Split message publish and routing</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/19e993fe1ffd4284655789adaca22e7758cabf9f...15a4a4503cafc257685e296e517b59be1e925a86