### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1683014792,
-        "narHash": "sha256-6Va9iVtmmsw4raBc3QKvQT2KT/NGRWlvUlJj46zN8B8=",
+        "lastModified": 1683194677,
+        "narHash": "sha256-Am7aCGNy/h6RMnvg7Pn4PHQXZZq9FyIUA9klYxBwyDI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1a411f23ba299db155a5b45d5e145b85a7aafc42",
+        "rev": "0d8145a5d81ebf6698077b21042380a3a66a11c7",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1683176385,
-        "narHash": "sha256-J/P6C6sobyabRN20/RgruIp6rK3A9cwLaB1pLlpn/qM=",
+        "lastModified": 1683202281,
+        "narHash": "sha256-ekEIn9LwWyjzwPmRIavLcfAE/PWT5gdJGKqVSCmwrNI=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "15a4a4503cafc257685e296e517b59be1e925a86",
+        "rev": "35e89494a9469a3b08136900b1974d6fd84f5430",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230504";
+    octez_version = "20230505";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/2331787b70d5f3e153dfe7274b65eb59b760cd88"><pre>proto_alpha: copy operation encodings as legacy ones</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1252aeadfd60e875a7692385021382ef908dc1a3"><pre>proto_alpha: use legacy encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/280262b9376f8302afc6b0cd2a95e7c6c6e55f45"><pre>proto_alpha: introduce attestation encodings in the non legacy</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fceb0824d3451d48f1f775bf497e3a30495e15ee"><pre>proto_alpha/lib_client: add operation_with_attestation encodings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/72d11b98fe87db5d1132612f1d00fd750b9894b8"><pre>proto_alpha: test both encoding and legacy_encoding of operations</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0e560aa1630c0f4b373ca6973e6eb8512d3b3c18"><pre>tezt/tests: add preendorsement operations sample to the encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/aacce8a89daf8edad1f3b6053d2672478b94cf05"><pre>tezt/tests: add encoding tests for operation_with_attestation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6b649e913395d3b55b3d1fe76ce5e5fe6e2f4dd2"><pre>tezt/tests: add sample as tag in encoding tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5a812a5ecd7ac1c38d6c2abb19edfa2056fa56b4"><pre>changes: add a client entry for the new registered encodings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9eccbfc53879796048eb10163298259075af1096"><pre>changes/alpha: add an entry for legacy operation encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9f8b3aed773f3e07f7148f23ea967a2195dbc127"><pre>Merge tezos/tezos!8563: alpha: introduce attestation encoding and version 2 of operation encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/33c387f17ab6ce67f0a85964c4ac95c3a188182a"><pre>SORU: EVM: import of minimal evm kernel from tezos/kernel</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/17ac8a7a7817c8baed760a4d4e7adc6c24b2b5cc"><pre>SORU: EVM: benchmark creation scripts</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/20738e1e430c98cb979401310118f1f853ee99fb"><pre>SORU: EVM: benchmark kernel doc</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4b6749ad08659b7ee0a5ef6431f5530a0c63de86"><pre>Merge tezos/tezos!8330: SORU: EVM: import of benchmark kernel</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/684cae83db6e9c21bd440435f0388399540d36c5"><pre>lib_plompiler csir: generalize [entry] and [partial_entry]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dab65f2ec1cf23b0c0f63a378b70c0e76ccabeaf"><pre>lib_plompiler csir circuit: generalize [q_list]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5ae0b12fb5cc845c5070a797717404d404cebee3"><pre>lib_plompiler csir: generalize [Wire] case of [selector_tag] variant</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5bb1287420af13ada44b6a3a952b1ff11687fbd9"><pre>lib_plompiler csir: generalize [raw_constraint] type</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f5932c89cf7e42980793320111947f5326cc511b"><pre>lib_plonk: generalize [make_gates]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/166d2037b2ed9f8904a13681dbccdc43fd7d1c92"><pre>lib_plompiler csir: generalize [wires_of_constr_i]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2c7e08d6af4e0ba7aaf5c15bdda7ffb342a43beb"><pre>lib_plompiler csir: generalize [table_or]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b29f8786c370e171b225083f5441af483b1a7983"><pre>lib_plompiler solver circuit: generalize [arith_desc]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/35a33f6b4ad9994f009f7c7d697d0fc0b6ec1a1d"><pre>lib_plompiler solver circuit: generalize [wires_desc]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5894ec4c28b0fded128406fb248ef56193cb98e6"><pre>lib_plompiler solver circuit: generalize [lookup_desc]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2115ba7d865b237d680d249d06f9338df7133eb3"><pre>lib_plompiler csir circuit: generalize [new_constraint]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3d705a3667c5f9fb989df71f0316e9a0f212ca07"><pre>lib_plompiler utils: remove [map5] function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4ee759fe804d4ffe720f5b94943007b998fce11f"><pre>lib_plompiler circuit: generalize [append_lookup]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/75aeb2fdb3041fc8a44c939c957e0d050426cf3a"><pre>lib_plonk circuit: generalize [sat_gate]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/331e05afb518ad4fc415b823d6f3afc8ca3aa1b1"><pre>lib_plompiler csir: generalize linear selector names</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/87d8a83dd4c70142eee3ded0000fa1a0ccc34673"><pre>lib_aplonk: generalize permutation argument</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cc82541c9e0edcf52a5794556739513503786bfc"><pre>lib_plonk: generalize names of T, Si and Ss polynomials</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/35e89494a9469a3b08136900b1974d6fd84f5430"><pre>Merge tezos/tezos!8436: Plompiler: generalize the number of wires in the architecture of PlonK</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/15a4a4503cafc257685e296e517b59be1e925a86...35e89494a9469a3b08136900b1974d6fd84f5430