### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1682984683,
-        "narHash": "sha256-fSMthG+tp60AHhNmaHc4StT3ltfHkQsJtN8GhfLWmtI=",
+        "lastModified": 1683560683,
+        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "86684881e184f41aa322e653880e497b66429f3e",
+        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1683194677,
-        "narHash": "sha256-Am7aCGNy/h6RMnvg7Pn4PHQXZZq9FyIUA9klYxBwyDI=",
+        "lastModified": 1683408522,
+        "narHash": "sha256-9kcPh6Uxo17a3kK3XCHhcWiV1Yu1kYj22RHiymUhMkU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0d8145a5d81ebf6698077b21042380a3a66a11c7",
+        "rev": "897876e4c484f1e8f92009fd11b7d988a121a4e7",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1683202281,
-        "narHash": "sha256-ekEIn9LwWyjzwPmRIavLcfAE/PWT5gdJGKqVSCmwrNI=",
+        "lastModified": 1683838617,
+        "narHash": "sha256-FGOqfDDiQWQW1zCLlV2ds02MIJ8/7tiMX3pUsk8Ugmw=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "35e89494a9469a3b08136900b1974d6fd84f5430",
+        "rev": "1c065879189e82f7f8b2d7bb945d79f64416af3f",
         "type": "gitlab"
       },
       "original": {
@@ -276,11 +276,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683117219,
-        "narHash": "sha256-IyNRNRxw0slA3VQySVA7QPXHMOxlbx0ePWvj9oln+Wk=",
+        "lastModified": 1683307174,
+        "narHash": "sha256-A7nF2Q+F+Bqs4u6VS4aOzyURfly5f4ZAiihGU0FA29g=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c8c3731dc404f837f38f89c2c5ffc2afc02e249d",
+        "rev": "b44794f94514b61512352a18cd77c710f0005f15",
         "type": "github"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230505";
+    octez_version = "20230512";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/83bd6068b8c1dc9cdb8cdae1b8481055b6e5d9c8"><pre>Alcotezt: port [lib_mec/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ae014d33f331ecd8f8641abe4e064437a9e174a2"><pre>Alcotezt-ux: add header and invocation header</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b4cca8631d488f6e123968db6e451538feed99af"><pre>Merge tezos/tezos!8587: Alcotezt: port [lib_mec/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8da2d9bd90420da9c5d4519235d07d0af43eae9c"><pre>SCORU/Node: only store finalized level instead of L2 block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4e4fa8282efeabc7cc1cce100af6bea9a1e633e9"><pre>SCORU/Node: use finalized level where possible</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b9c736b959966b449636ad687ee953e41af81347"><pre>SCORU/Node: remove useless handling of finalized block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0b547f8bcf4bb029427fdc67a92fc35c9ed120f7"><pre>SCORU/Node: backport !8524 to Mumbai rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bd4db67d0e8496b78d55861a2946be2d982f2b5e"><pre>SCORU/Node: backport !8524 to Nairobi rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/83c65e8b6cf3ddc7bed9341c7c4c9650de3ce132"><pre>Merge tezos/tezos!8524: SCORU/Node: remove useless handling of finalized block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8beb4b812e95fd98d4a936a6cd1c15343a97758b"><pre>Doc : update Alpha changelog</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d884bf520ff8f481555ecc7863467b5adc72b07c"><pre>Merge tezos/tezos!8616: Doc : update Alpha changelog</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f65811c6b670a82718286bd280848425e54eb62c"><pre>Manifest: initialize protocol agnostic library for smart rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2f4096703dda45e6506bc4d365a10c5d2e896174"><pre>SCORU/Node: configuration does not depend on protocol fee parameters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/355ec59c03872c9c7f38aa2faabc12ed9d1bd447"><pre>SCORU/Node: check fee parameters allow operations to be propagated</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/82ebbcccf7acf3b677470aa036f2a611fa4730f9"><pre>SCORU/Node: move protocol_max_batch_size computation to node context</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4f3339d0e3eb09aba995baa71d9c4eb2e66a2b09"><pre>SCORU/Node: use protocol agnostic rollup address in configuration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bd2668a15464c3ca8224c343f27db28c6fb08628"><pre>SCORU/Node/016: protocol agnostic configuration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f6df3180f61004b5e332f26b9751099d6d0929e1"><pre>SCORU/Node/017: protocol agnostic configuration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b88f5e14350f82a753ee1a6e6526293739ac283f"><pre>SCORU/Node: move configuration outside of protocol dir</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5853315db3302f308e05b9fbd14a9cf2603f9de2"><pre>Merge tezos/tezos!8498: SCORU/Node: move configuration outside of protocol dir</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/46398c51fcf32d5e04021ad2305b74516eddc060"><pre>Client: non protocol specific smart rollup alias</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d7a9509ba1704cc4cb744c3b80854318fed86ece"><pre>Client: smart rollup commands in base client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/240deaf96640d03dff7d97066c8a23d593a8246c"><pre>Client/Alpha: use smart rollup alias from base wallet</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7caeef7a804b0387f1a677a4d8a98c1909cc82a7"><pre>Client/016,017: small wrapper on smart rollup address alias</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fcb481bbbb22aee23db0b9aec3759e45873f4c0e"><pre>Merge tezos/tezos!8606: Client: non protocol specific smart rollup alias</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/98dd9188930e5a6b2e63f3ef034bc0e98ababe24"><pre>Baker: make context_path an optional argument</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/76aad73b59876b0988738dd38f0be171dc0a4970"><pre>Baker: expose an RPC-only baker daemon</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/da8a67897692c3d10383c48951b6e263fbb3a2f5"><pre>Baker: refactor baker commands</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ea61d8c7cd102285cdb53855591e5575c7af9522"><pre>Mumbai/Baker: port changes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1adfb450489bb52d1e2bc99bb54c7b63850b909f"><pre>Nairobi/Baker: port changes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d15b646afa5a2fba9ce836ad1b07941d7011275c"><pre>Tests: add RPC-only baker test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f2248d3bb36274e394585677f7526f417d366eea"><pre>Changelog: add an entry</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/441f6e7ed8daf23f7ff9361ae51489fbaecdb1e8"><pre>Merge tezos/tezos!8607: Implement RPC only baker</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fd868771adccae1c849e2916b52c1e2429d2316a"><pre>Gossipsub: add backoff to Prune message</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9eb99b0f739d17acac1c8c9624472da4654d1cca"><pre>Gossipsub: sometimes prune after an unsuccessful graft</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c2b16d0e631262db4adb86afdd5c714b39e8ba20"><pre>Gossipsub: rename Unknown_topic to Unsubscribed_topic</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/35fcbab976bc991242c130bebcfd5256b4138431"><pre>Gossipsub: remove outdated FIXME</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8310d3ae89cf56122ba898313eafaad75d5164f8"><pre>Gossipsub: improve formating in pp functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/96f6c5cbfe0a350350dbeccf7d748fe956d0cc9f"><pre>Gossipsub: fix test by using the right constant</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f7a56991bb36e088425ab2bd97470ec563304d59"><pre>Merge tezos/tezos!8651: Gossipsub: prune after a Graft when nedeed</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/499138f6f6963c384e2ddaa8a5172bfa46f439f1"><pre>Devtools/git-gas-diff: disable external diff</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9af8420f9c24b90162c34caa8bbb35c40f2db044"><pre>Merge tezos/tezos!8609: Devtools/git-gas-diff: disable external diff</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8aa3a4aa82d1acfc48f1b44f3ac344359d2b4525"><pre>CI: Simplify the workflow rules</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5eca0d2138b78132f203d1d487b6c83d7ecf43ca"><pre>CI/[.gitlab-ci.yml]: refactor [rules] for readability</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cda1f232f4c629f133990020e812d82a00735db2"><pre>CI/[.gitlab-ci.yml]: comment the \'test latest/tag release\' pipelines</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6d81b5205a9c825213ba17549466ead4284af8c9"><pre>[.gitlab-ci.yml]: Harmonize CI_COMMIT_TAG regexp for beta releases</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/16f5f79082a2532293c0ba081b61774d8a2073a7"><pre>Merge tezos/tezos!8586: CI: Simplify the workflow rules</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0c60f93f0bd2c35ac218b1f7310b6528dcd0f1d1"><pre>store: fix problem with duplicated logs in unit tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/78e5c873a58172d945e1f994c8b94888106f74b0"><pre>Merge tezos/tezos!8642: store: fix problem with duplicated logs in unit tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/af6964dc694c756f181195d2b756b85a8c52c773"><pre>Gossipsub: Expose get_topic_params for testing purpose</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8ac3a20565b63c12a58f93a1546c646ca7d2ed81"><pre>Gossipsub/Test: Change Time.elapse to take Milliseconds</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0bd770d2c5bc7b834548eef9d3250f8083071af2"><pre>Gossipsub/Test: Add Milliseconds.to_int_ms</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/43275669dde4fbb5f26ba8ef60711fbed1f1027c"><pre>Gossipsub/Test: Lower heartbeat interval in test_unsubscribe_backoff</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4476f14d92ff1b484647c1af1260b4a2ec919dc8"><pre>Gossipsub: Properly notify scoring about graft</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/429be4ff966a3f7046ce05ee7d4a5dacd10ef268"><pre>Merge tezos/tezos!8633: Gossipsub: Properly notify scoring about graft</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b761fbd016c0c2d1cf4cba6d1be0276a754a3f6a"><pre>WASM/Debugger: Custom section parsing</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cc67e60c0da9e65b05bd8c200ee17a3a2c3442c9"><pre>WASM/Debugger: add \`dump function symbols\` command</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8f5358a945d020aaa86c6c13e5c006d888beab74"><pre>WASM/Debugger: Update Changelog for \`dump function symbols\`</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/24df46325b23a550838fbbe55b36013d8c296414"><pre>Merge tezos/tezos!8522: WASM/Debugger: parse the \`name.functions\` custom section</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/64734a75bac528a5f76bf12dd36af5684d55aa17"><pre>WASM/Debugger: call stack computation generic algorithm</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9f73366ec1dcc11da0ee7db65b571d6d1a3e0186"><pre>WASM/Debugger: PVM call stack computation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5f81d36d5ab2677c6eca29257a258cecfc0253fd"><pre>WASM/Debugger: flamegraph generation and pretty-printing</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5ec80ef44656a626014daa66bfd7a22f63b9d4d6"><pre>WASM/Debugger: add a \`profile\` command that load inputs and start profiling</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4fb57af57763a732c42e89143cdfa7fab2b95377"><pre>WASM/Debugger: use the WASM custom section \`name\` for profiling</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/42f8b35304ebf455fde50499e42233f984373e56"><pre>Changelog: add an entry for the WASM profiler</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b1f18d303598cc284820eaf7cb697d95be349fd9"><pre>Merge tezos/tezos!8510: WASM/Debugger: profiling kernels</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/49a6ce5ea844be3f54237e38bc1d7ee3c9577adb"><pre>lib_benchmarks_proto: fix N_IUnit encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/875b45535f6de013109d2f3e18ecd114f6d85337"><pre>Merge tezos/tezos!8662: lib_benchmarks_proto: fix N_IUnit encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e3cd8b09a34ed1296f87bd71f981abd8cbabfccf"><pre>Ddb: fix missing sleep omitted in !8503</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fb813f8bd4d0692a4ddb8391411fdeb4eb14926c"><pre>Merge tezos/tezos!8671: Fix missing sleep omitted in !8503</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3efe3119f32fe87d05487d989833629c5e743a48"><pre>PlonK/RC & Perm: minor changes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c35d515c3c9216748a595c8d26dc6d16ceb8d7da"><pre>PlonK: move shared permutation related in Permutation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/165d2a9861eadb502063a1445ece4653bdca4d8e"><pre>Plompiler/Csir/Scalar : change string_of_scalar</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/276ad69c2c488e4840e191537d5715007b110413"><pre>PlonK/Bls/Scalar: use Plompiler.Csir.Scalar</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9b0f3d4086cb48a999eae17cd8b91cfd8d651350"><pre>PlonK/Test_RC: rename circuit</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/60695fd1565fb7f1653c0e34f7ce4fbe46cea48a"><pre>PlonK/RC: multiproof support</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d9e57b02e3bde0e4b3d9ef647424896f0d160804"><pre>Merge tezos/tezos!8423: PlonK/RangeChecks : handle multiproofs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/57a688761676501d84ceefdd924f09b7d4174344"><pre>SCORU/Node: remove metrics dependency on protocol</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a073578b8fd6a4b5941ce5479a5ca920a01132af"><pre>SCORU/Node/016: remove metrics dependency on protocol</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a32a3f663866e51dea2c20fd6dcbd01e5501c787"><pre>SCORU/Node/017: remove metrics dependency on protocol</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5204d05d93a089badb9c8420745a0c7a62a138a9"><pre>SCORU/Node: move metrics outside of proto directory</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b3d1ff53845a5d99d96a20150c93a1bf78dc1fdb"><pre>Merge tezos/tezos!8530: SCORU/Node: move metrics outside of proto directory</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/41c1139aba794dee7026e44683984ba46ca431f1"><pre>EVM: use u64 for gas_limit representation for uniformity</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/69b2c101ce2abd4ec0bdbcad5b02b2685ac9a724"><pre>Merge tezos/tezos!8629: EVM: use u64 for gas_limit representation for uniformity</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/97994b6bfb983c3b950f74673d4f94227896c619"><pre>Alcotezt: port [src/lib_srs_extraction/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8993bd2e2df96974055b4138b235cff79a5a8372"><pre>Alcotezt-UX: add copyright and invocation header</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fb5907e2f9e67e7584d2f46272e5cdbb0692908f"><pre>Merge tezos/tezos!8655: Alcotezt: port [lib_srs_extraction/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/89936d65a231acb9d92c87857bf3b02450c451a0"><pre>Client_make_run: set default logs directory</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/64e7a1fe6a906314a5ddab3c88e1a566659cea64"><pre>Baker: enable daily-logs in the baker</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/052fbc9a7eed6d3d608e12636c9516d9b6481653"><pre>Logging: update documentation with new baker configuration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fa14ff39852de9eaadadbf1148c058222815e9a4"><pre>update changelog for baker daily logs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/174938a1094389cf047e8e9dc552e0595f192c35"><pre>Merge tezos/tezos!8232: Baker: setup daily logs by default</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2b1b00951927af54f6ccfe881503d107c94d74ae"><pre>EVM/Kernel: fix missing nonce check</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/483e78ce30f4024a1f0a2ee0e8052f94f0a1e65d"><pre>EVM/Kernel: readapt current tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/89a82e6d74e340d451677fd5ec2238591c89d876"><pre>EVM/Kernel: replay attack test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9d7aec527a5f14a908b730aa486a6b6849f74cf0"><pre>Merge tezos/tezos!8652: EVM/Kernel: fix missing nonce check during transactions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f301350a48346b622a50f00ef675a3eea876fe5a"><pre>SORU: EVM: small improvement of signature script</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b364162ae1709f0e427a1cd34fa9ee5a726b1eaa"><pre>Merge tezos/tezos!8654: SORU: EVM: small improvement of signature script</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c28976938e4a324ae10f7583a551aac7d18c1590"><pre>Docs, v17.0: Update release page for RC1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/32427dc4a3b9cd346bb723b2213913465ad685bb"><pre>Changelogs, v17.0: Snapshot changelog for RC1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a69f794d882bd2bfd33cd32282c1150b15d0812a"><pre>Openapi: Update openapi generation for Nairobi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3fad8dcc43d1a5b3cc5808c6879a90e44861a32b"><pre>Docs, Openapi: Openapi for v17.0~rc1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dca8220d31b5fd4c07335c77d469b7924c2aec28"><pre>Docs, Openapi: Update Nairobi Openapi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/45ef7ec7176abe4415f1630b062fb861d7530602"><pre>Merge tezos/tezos!8634: Docs, v17: Documentation for Octez v17.0~rc1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/740eb32fce70de61a67dd2431ec70e84c45a6e96"><pre>PlonK/Tests: move range checks in cases</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/79dade09c5277d3593bb76e3278bd6b134ab1195"><pre>PlonK/Permutation: sort wires names</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/56b7d1c9228ad01b71afaea64a35c83188a2a2b6"><pre>PlonK/RC: make permutation order independent of poly’s names</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1d915d2175f1e91b979b0cf41479825402223ab5"><pre>Distributed-PlonK: fix tests when several uses of DP modules</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f2a1af2adc27927d1262521a1b1d2d46052d0479"><pre>Distributed-PlonK: fix wrong module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e5eeca688e3bcbe7e2dd17590b5c928cc1a17fb4"><pre>Distributed-PlonK: compatibility with range checks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8c874f514a0f56450459ce7f643457e7fd810586"><pre>Merge tezos/tezos!8424: Distributed-PlonK : handle range checks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/77fcdb6fe8f9d89e8c89614ea98fa737971e1aca"><pre>SDK: Delegate the consistency of the layers\' storage to layer.rs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7fab4061c805fc53f7a3382dc678c41bf5bb696e"><pre>Merge tezos/tezos!8646: SDK: Delegate the consistency of the layers\' storage to layer.rs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ce4cb119a73d32fb2fb22369aeb8698a25abaf8e"><pre>EVM/Sequencer: use rule build only</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b62bcb7f16fca57ff5d4bdbff3008701f5938d49"><pre>Merge tezos/tezos!8683: Kernels: use rule build instead of all</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2dc3aa49877a67cbf8cec2a96b7146dde3aed2f1"><pre>WASM/Debugger: fix profiling with reveals</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cf5c34cfec5b09daa62581f2b16b150a4c49b46b"><pre>Merge tezos/tezos!8675: WASM/Debugger: fix profiling with reveals</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b6ab318d5792860aaebe68dcd637fa817d02a3ac"><pre>Alcotezt: port [lib_bls12_381_hash/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/23146919202fa21aeeb949cee6213baf41faaa55"><pre>Alcotezt-UX: add header and invocation header</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1a1081c39983f02cacedbd8c8617748ae465c3fb"><pre>Merge tezos/tezos!8585: Alcotezt: port [lib_bls12_381_hash/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/024330f572bb536718cbe3e3d1b152b9c079fae2"><pre>Dac/Client: Initial commit</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d1e899dacdad42edcc0a5c93baf606e8f4dc8084"><pre>Dac/Client: add to gitignore</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/89e8955a18852c20e66366da8b8e6057fb12b636"><pre>Dac/Client: command for sending payload</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ccab3daa6ffcc93865705bf18def6bf669c14ce7"><pre>Dac/Node: move monitor services in lib_dac_node_client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e18e8eacee721c30408cdba1e9dd2326726ca0df"><pre>Dac/Client: add logic for receiving signature updates in client command</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5ba62a0f15d129410601e58159cc7f9f4536b8ea"><pre>Dac/Client: add logic for getting certificates</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f893a6a6d5da283614bd46f3fc0067577ae99a24"><pre>Dac/Client: add .mli files</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3a1bff19dedeaf353b16d8a3a08853fa41e6206b"><pre>Dac/Node: small improvements to raw_hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/329a49897305012997971b1a9aa553c598a0b72c"><pre>Dac/Node and client: add TODO for timeout on certificate streamers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d4a6557cb456c83c15e0ff1f0657988185bbca8e"><pre>Dac/Node: todo for testing witnesses certificate field</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e97d78ba0a63664d1926f96b85f69efb46be5d26"><pre>Tezt: Dac client commands</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c914b7ccebcc46c9353eda7f3774322a79ef7c0d"><pre>Merge tezos/tezos!8533: [DAC] Client binary</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2c78044e600a33d4c06c006b1de925fac4b8b2d5"><pre>client: replace camel by snake case for module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0a7be540dcdaa4b778f860ec78408192afd3faf7"><pre>backport: client: replace camel by snake case</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f7ba65aa2bbcbab598979150a8d333ea653e5550"><pre>Merge tezos/tezos!8422: client: rename module name with snake_case</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cc8fdada1841649628a73c51777a117daea9b159"><pre>PlonK/SMap: small change</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7a644dd9954c1d841be59758e9d33b4bdb149ae6"><pre>PlonK/Permutation: refactor cs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b5601ffa4e01015e283af100a7b6d09a190841d6"><pre>aPlonK: introduce range check protocol</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/84f22e8ca7274039f901e3460abd3598f5258f6e"><pre>Merge tezos/tezos!8425: aPlonK : handle range checks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f6750f45d3a736f7ab57b0503fbebff507ceba46"><pre>Sinks: add a new kind of pretty printer reproducing lwt-log behavior</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3942156eec43c65ecd923d6fd062a395c87335ec"><pre>Sinks: move some code around and simplify pp interfaces</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/38cd4b3ffb205e2c781dcaaf90d30406676b8bb4"><pre>Sinks: add expect tests to a functions manipulating dates and files</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0a8666ee57a5fc1599291119a685602080d7cc73"><pre>Sink: add assert false to printer to explicit impossible case</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/32dabd204590637702babd556709ae12d39c3439"><pre>Merge tezos/tezos!8173: Log sinks: introduce human readable pretty printer (lwt-log deprecation)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b5fed30a43350e26cbd2beb84617f6e31efc854a"><pre>Store/consistency: fix wrong context hash checkout</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/abdeebf01697e614dda2612883de59be77a33e1e"><pre>Store/consistency: fix protocol activation search</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1eabd87df6f5b2633458931f235ec5819fae2877"><pre>Store/tests: improve consistency test coverage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9491749218ce3af5011b968aa4863c7620b910d9"><pre>Merge tezos/tezos!8373: Fix store\'s restore consistency</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b2d4a720d78aadd799a822b0dbabac0c5ce4c228"><pre>Cryptobox: export encoding shard_proof_encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/27cf8c467ebfb635da0894bfe255b94c786b509b"><pre>DAL/GS: remove function mul_span from Time to Span</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e395914a9f11a77dbce242cf0c3d37a7e54a34d8"><pre>DAL/GS: fix in gossipsub_intf</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ccf92bd66dcbfc381a7de8088123d702ec334707"><pre>Cryptobox: expose compare function on commitments</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ac02e9559b930ef201cd323aedbdcb57a25551c3"><pre>Manifest: add deps</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d090f76663e440514d93f1e109b490cc9afcad35"><pre>DAL/Node: implement the GS interface</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b843514f09359777eb202c05c2d81b1c17d7e936"><pre>DAL/Node: introduce the default constants for GS parameters and limits</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7f41d2b67600b638e743723a83e39f1893392b0f"><pre>DAL/Node: expose the different GS modules in gossipsub.ml*</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/18ef6670e67d09de0f8f7a58d42783fb03533394"><pre>DAL/Node: add a dep to octez_gossipsub in bin_dal_node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3a05db24b3c98e9e808c1d0d6720653fc059158f"><pre>DAL/Node: define GS limits and params (using defaults) in bin_dal_node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1d670163db8f1d3b7586c357cbb9c9530854b507"><pre>DAL/Node: plug gossipsub worker in DAL node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d29189debffe19f475b4156e4c5131e35f6baafe"><pre>Merge tezos/tezos!8577: DAL/Node: instantiate GS worker with DAL node interface</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5d77b6f4af5344cf8df446115259fdcea991bfa4"><pre>client: remove (assert false)/error in sapling cmd</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/73548ab6a1ff83a0d69a1ef0e2faf28778537502"><pre>client: remove (assert false)/error in context cmd</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2a8bb25033bf41a11da07a7bb1a0eeef784e65e9"><pre>client: remove (assert false)/error in stresstest cmd</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b9eb8fd529799ce245fb517d1eeefbbcee10a50f"><pre>client: remove (assert false)/error in multisig cmd</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c2ce7fd170ce1d76bc7eef84fd6f19d65dc9902c"><pre>client: remove assert false in fa12 cmd</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9f28ddb2fa44f4254dc54dab309cb512f4e94a76"><pre>client: rename variable with more explicit name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e1f258f52b6c727095f3992618574834cd00bfb0"><pre>Merge tezos/tezos!8619: client: use appropriate param to remove assert false or error</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/50d424a176fe48d8a0c18ae1ab28596f353a3639"><pre>Smart-rollup-debugger: Print hex hash of reveal preimage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/97b5657bf7d7d25d8a042a45e8ff91db128ac82b"><pre>Merge tezos/tezos!8692: Smart-rollup-debugger: Print hex hash of reveal preimage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/128ac2a3fa19a95f810219ef7d71eb640d1cd3a4"><pre>Dac: proto dac client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/99314c3e844332ddea7ad656bcebba5fa26fde22"><pre>Merge tezos/tezos!8033: Dac: Rollup integration - dac observer client</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d66948db2a9a864128790c9aebc162a2e187a198"><pre>Tests/store: minor test refactoring</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/384faebca62a89e8117eb4e474f8006762257ee3"><pre>Tests/store: improve test consistency</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/06c5b356bbfd30f5776fc34ab1cceea7e3f539d7"><pre>Tests/store: enable context callbacks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1eefa1695403d1630c7f78fb9aec9d12d815e1de"><pre>Merge tezos/tezos!8664: Improve Store\'s tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cb3fc7285f02355a225305637718223a74657253"><pre>Build: Fix clean-kernels</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d85b6f610f9f940fa15b27e3dd8fffdeb3c2c3e2"><pre>Build: Remove clean-kernels from clean</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8bd02f1c5b910b3e820571016ef4f11a41ac3d82"><pre>Merge tezos/tezos!8695: Build: Fix Make clean</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e43a7266622a09267565e7be3e68c0702fac3bb1"><pre>PlonK/RC: small change</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a7c4d8e36a0addeeab0dfd1c4bfd4a2a74b9bcea"><pre>PlonK/RC : several bounds</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/56609da3898094d1dd861c22b6d0a58e31b916ae"><pre>PlonK/RC: add test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/67a6a1bbe2557b85c9d31b28d090729697b76b0f"><pre>Merge tezos/tezos!8442: PlonK/RangeChecks : handle several bounds</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6b7d94df35c84907694c68d5644015ff1da98889"><pre>Proto/Delegate_missed_endorsements_storage: use weight instead of Tez to compute expected slots</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1c0476e401a52ce0afe8fa1bdda053854a95dca7"><pre>Proto: add Stake_repr</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a8177d4505191fa2e796068d8589e7408cae189f"><pre>Proto: use Stake_repr for the selected distribution</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/10e82133f7260be2fd2fad7266cc4d6ec3372437"><pre>Proto/Delegate_sampler: minor rewrite</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/72844fca7c3755cba513007e20439e35c59794e0"><pre>Proto/Stake_storage: minor rewrite</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4a519cab396b0a08a862a8cf3f7b00c65f11e6b0"><pre>Proto/Stake: split between frozen and delegated</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/08a8b1b815ab560baa95b483c1114e17f70020ed"><pre>Proto: add stitching for stake distribution</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/59fdd4d827990bc29f63714fb910075607e69a87"><pre>Merge tezos/tezos!8051: Proto/Stake: split between frozen and delegated</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/38f9be2544f039bd4192d8fcbcdec864257e6f6b"><pre>add adaptive_inflation feature flag (1/2)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/10c8076ef322dcada3443a2de0ca6f4f8f5242a1"><pre>add adaptive_inflation feature flag (2/2)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d5e488be97249ff21cf57ccec64165fb86068481"><pre>Proto/tests: update regressions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/be9487709146d1f65d90f47d3a25cf60b098d564"><pre>Merge tezos/tezos!8566: Adaptive inflation: add feature flag</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6757006418e92705615b9a961f7a859eaad71112"><pre>Dac/Node: allow incoming connections independently of RPC server address</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a6ad41754a22a3451e166de623fee424eb03e885"><pre>Merge tezos/tezos!8701: Dac/Node: allow incoming connections independently of RPC server address</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9094f6ff0f54b9a6d11e6846306303f9949b0779"><pre>Proto: add Delegate_rewards module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ecdde3d364deb754b0a5e3956b2ebffec3daebe3"><pre>Proto: include Delegate_rewards in Alpha_context</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a083401e47df96e151f2c6f8cddb2a9736eccdfc"><pre>Proto: replace reward constants with calls to Delegate.Rewards</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5603fae473f351877065be2292ccc1ba49e59b23"><pre>Proto: distinguish between vdf and seed nonce for revelation rewards</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b9e29e3f75942334a7757efaddb0742062ae1586"><pre>Proto: replace reward parameters with weighted rewards</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/047303b5803b1a6204bbcb84fc89b11fc73f67a9"><pre>Proto: compute correct rewards from parameters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/683aea22443fb1f67c4f648238b7a6879a2a14a2"><pre>Proto/tests: update reward mechanism in tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/adab7a3bb6c1c63ee372c044df59e668907d43fd"><pre>Proto/tests: reset regressions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1c065879189e82f7f8b2d7bb945d79f64416af3f"><pre>Merge tezos/tezos!8657: Proto: rewards expressed as relative weights</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/35e89494a9469a3b08136900b1974d6fd84f5430...1c065879189e82f7f8b2d7bb945d79f64416af3f