### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1684049129,
-        "narHash": "sha256-7WB9LpnPNAS8oI7hMoHeKLNhRX7k3CI9uWBRSfmOCCE=",
+        "lastModified": 1684139381,
+        "narHash": "sha256-YPLMeYE+UzxxP0qbkBzv3RBDvyGR5I4d7v2n8dI3+fY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0470f36b02ef01d4f43c641bbf07020bcab71bf1",
+        "rev": "17a689596b72d1906883484838eb1aaf51ab8001",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1682596858,
-        "narHash": "sha256-Hf9XVpqaGqe/4oDGr30W8HlsWvJXtMsEPHDqHZA6dDg=",
+        "lastModified": 1684195081,
+        "narHash": "sha256-IKnQUSBhQTChFERxW2AzuauVpY1HRgeVzAjNMAA4B6I=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "fb58866e20af98779017134319b5663b8215d912",
+        "rev": "96eabec58248ed8f4b0ad59e7ce9398018684fdc",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1684131543,
-        "narHash": "sha256-f3Y77Dw7JCNrvtETGRxYz8hTrTny/yjBKa4J8eq9CqY=",
+        "lastModified": 1684190043,
+        "narHash": "sha256-KZ0P6mlRLQxGfAW/ZvzjzAfqc/d08tXyEQNir+W28Zc=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "d5a08a5c3ac1b3e7d177fa38d5de3b0e51b77584",
+        "rev": "390ed13f40946dd158221e6c232610f34de9ad5b",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230515";
+    octez_version = "20230516";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/732dc13f9132e1f5edd545906ce27cfd97c94b28"><pre>Shell: mempool: bound not only op count but also total byte size</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c77ea07877d0be4fe4876ecf3fc0a416725f8d11"><pre>Shell & plugins: remove obsolete bounding code from filter plugin</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5fbd77d092350122465a11d242bdc0fc45c4ac54"><pre>Plugins: add mempool.mli</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/12d34f949c0ae60f5ff50448e00f8f6d702706d4"><pre>Shell: make the mempool bounds actually configurable</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c8adba1de4a3403f97359dad403347f13718d51b"><pre>Shell: make signature_checked field configurable in tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/58a82538e69f1be119447e2b32e6389f4e6eeb4f"><pre>Shell/test_prevalidation: check returned op</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ef4eb76767bea4b4497bbaa2e9330f9c75a51378"><pre>Shell: add tests on mempool bounding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4d3a7317aebed7c01b4f9c1d683bb46b87249868"><pre>Tezt: update test get post mempool filter and move config helpers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/442c85d50857a60f7de6014295820b40d888f8fe"><pre>Tezt: update prefiltered limits tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/110f5ff857ad556c600e3968ff1b2357ac7b26c8"><pre>Tezt/RPC_test: update regression tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/16f11176a697799291b8f3ba70563b783d59783b"><pre>Changelog: add entries</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/89e8c7a809d2b2f15b6ea041c9c0eaeebce8146a"><pre>Merge tezos/tezos!6787: Shell & plugins: bound the mempool by op count and total byte size</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9375afe88f7efbeec436b4b2089bd62255db0f55"><pre>Benchmarks: automatic run documentation.</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d9e5f4b34939a3c61e5fa9c41beba7355c202ff1"><pre>Merge tezos/tezos!8429: Benchmarks: automatic run documentation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2fac3fd7c43a427d92ae961540c56489b21e9b98"><pre>Gossipsub: fix issue number</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9236822f52a8facd2ebf941a8f6978af0fc50c95"><pre>Gossipsub: fix docstring about message ids</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/17e361b6486198d5741250b86a1402684adc3890"><pre>Gossipsub: rename No_peer_in_mesh to Topic_not_tracked</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7f5fb53f3c0a72cd50f47ef30ee98c104ef50a94"><pre>Gossipsub: invert order of function calls</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f888a8c354d00e32e8566a35186e7c802a6deb70"><pre>Gossipsub/Score: uniformize doc-strings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fe86e6d9f6132c3362b118c0523d5db6d0d26684"><pre>Gossipsub/Cache: add issue about duplicates</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5c5e3508161f5801dda872d2523375695c149d84"><pre>Gossipsub/Cache: improve doc-strings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/22fcb468887320e0b8746738209ca4313ff4c010"><pre>Gossipsub: document the automaton state</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ae8c312125885f4152d362a8a40d4b40dc180b06"><pre>Gossipsub: move Message_cache interface to intf file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6d005c88c27dfba5b5b6b98e46dc48083c245b4c"><pre>Gossipsub: add output for announced pruned peer not in mesh</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/192f60fc70ee164927f343f0a07b0e2f311b7ee9"><pre>Gossipsub: rename score parameters to score limits</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5996a9ef53f523a090659ac7b4e8c0f8b3d8e108"><pre>Merge tezos/tezos!8698: Gossipsub: various doc-string improvements</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ce72b04b39fde0d4667045b2192e0f7a3b1da8e2"><pre>env: export Make_merkle_tree functor from Blake2B</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9a5cb5f0172c843b238dd9208e4d330ae6cf2180"><pre>Merge tezos/tezos!8709: Environment: add Merkle tree module from Tezos_crypto</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ca98d6dd3107aeb2647b59d4691311f0298d97b1"><pre>Kernel/SDK: abstract storage from \'account\' terminology</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a541f5e4a3dce5a1e9a00141ad9a4b9de02d092f"><pre>Kernel/SDK/EVM: readapt tests/docs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e8cd38de96dc2db74e90615eb557038e1b8d10b4"><pre>Merge tezos/tezos!8735: Kernel/SDK: abstract storage from \'account\' terminology to make it generic</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4fbf9b5951c4ca40fbbafcfa71fee46320d68471"><pre>Kernel SDK: bump tezedge deps</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6304884ceeebbd21073a4f42b374aabcc10a74bd"><pre>Merge tezos/tezos!8725: Kernel SDK: bump tezedge deps</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eed845bd13d6ae6e47350529cbc80fdc5a1c677b"><pre>Lib_crypto/timelock: updating chest_sampler</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9812bbe021df643d8e49c9604add1a9270792a17"><pre>Proto_alpha/encodings_benchmarks: updating timelock</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b136e7795ba90de9a537457f6abe07477de30982"><pre>Proto_alpha/interpreter_benchmarks: updating timelock</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c5e3e16e38e1a5d8725a90864b0b20310d6c5f81"><pre>lib_crypto/timelock: update test sampler</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1a27f7b46bf371d0382d7aff72fb6c2d54125fd1"><pre>lib_crypto:fixup timelock.ml</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/327a0b1b38cf476800ab3762ec388b5e19f5ad22"><pre>lib_crypto/timelock: updating chest sampler for determinism</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7077bea22ff83db825d9fc3009a85d8057a7f4a1"><pre>Tezt-timelock contract: update time</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a030525d9c633ea134280338b35b2916260ab1f1"><pre>Lib_crypto/timelock: adding comment</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ee89fefa55bd19644c3a013bfd44519cfceb15b5"><pre>Merge tezos/tezos!8494: Timelock - patching benchmarks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ddc857b4cc112ddc4226c513fce585a122021fe7"><pre>DAC/Node: remove threshold from coordinator configuration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8441e6ca77e4e8cbac0d0d5f7a7af2ea38d28a4d"><pre>Tezt/Dac: remove coordinator threshold parameter</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b23c83a805fa939409ea9f5355277b65a1730a6a"><pre>Merge tezos/tezos!8635: [DAC] Coordinator - remove threshold parameter</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c3b4eb1f65a92758918e5ea2e03b2fec4f568aed"><pre>Benchmark: fixes printing of Free_variable.Set</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a6a968dfd90949b3d9e3fac23bf8f382c48b7f5c"><pre>Snoop: adds \"generate code for benchmarks\" sub-command aka auto-build</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3298fe67026637d4d2471faaa932ec44d3614d65"><pre>Snoop: auto-build: adds inference CLI options</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/414ccd6930eeb420b457640ddce80619255fc043"><pre>Snoop: auto-build: adds --bench-num and --nsamples</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/390ed13f40946dd158221e6c232610f34de9ad5b"><pre>Merge tezos/tezos!8151: Snoop: adds auto-build sub-command</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/d5a08a5c3ac1b3e7d177fa38d5de3b0e51b77584...390ed13f40946dd158221e6c232610f34de9ad5b