### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1684215771,
-        "narHash": "sha256-fsum28z+g18yreNa1Y7MPo9dtps5h1VkHfZbYQ+YPbk=",
+        "lastModified": 1684305980,
+        "narHash": "sha256-vd4SKXX1KZfSX6n3eoguJw/vQ+sBL8XGdgfxjEgLpKc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "963006aab35e3e8ebbf6052b6bf4ea712fdd3c28",
+        "rev": "e6e389917a8c778be636e67a67ec958f511cc55d",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1684298215,
-        "narHash": "sha256-SpN4NP9rPT1rpbzo2AjAU7mHJnakCX2g/4D4Ugmnnvc=",
+        "lastModified": 1684389502,
+        "narHash": "sha256-TQkv8aGNVqgNDhWsaP+OKUfy7Ax4bkS84aNTIrqBL9s=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "6064e8b7052294305324ca1925c128414f3cd345",
+        "rev": "fd754eceb3a2d4d91c1908f27541e279bcf3fa06",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230517";
+    octez_version = "20230518";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/df5b2282b206fff713003d5a053ae24809034a6b"><pre>CI: Revert tezos/tezos!6787</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c899e77a65a17409a60e172e5ebd87400c23796b"><pre>Merge tezos/tezos!8769: CI: Revert \"Merge tezos/tezos!6787\"</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bb359921d45549b345fd907f0a815fbc5a44bead"><pre>Proto,SCORU: Add unit test for the reveal instruction</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1f8b8ebb203e9cb226591ae819c8c5637454679b"><pre>Merge tezos/tezos!8742: Proto,SCORU: Add unit test for the reveal instruction</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b1b99b10e5cec69ce707b34e36ba7f6375fc3f83"><pre>WASM: Functorize the debugger</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f914989a445e957edc80e78662f663a6d353f986"><pre>Merge tezos/tezos!8638: WASM: Functorize the debugger</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8900a23c77ad875943e99190066360167049fd5d"><pre>SCORU/Node: fix permissions for store data file when run in readonly</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bcfa2286487e42a3d49d7a52319030ae7c586f57"><pre>Test: test store load</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/74854d064680ac9dfd01dad3fc8529ebc064fb7e"><pre>Merge tezos/tezos!8687: SCORU/Node: fix permissions for store data file when run in readonly</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8f927de634d5cb65f3c4e3cd7e873bbe7c35b5cf"><pre>kernel/sequencer: add an input predicate</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b806a2406251b9eddd5f7269b68d1ca86d142e09"><pre>kernel/sequencer: add input predicate to macro</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a1b9b940f807568085325e79ce30c9f19ab90802"><pre>Merge tezos/tezos!8668: kernel/sequencer input predicate</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fe7294fc352ebf9451d8c6689c110fa564d85ee5"><pre>Proto: add parameter staking_over_baking_limit</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/37588113f2dbc8feb18a3a0b1dd9f67c26786d24"><pre>Tests: update regression outputs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5c3c94a25ac8e5257cacbe4db406a952a846073e"><pre>Merge tezos/tezos!8744: Proto: add parameter staking_over_baking_limit</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/be72e94c9d66f022c6c5b701fa6a0de6a6d6f8d7"><pre>Tezt/long_tests: disable [script_cache.ml] tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/19de6761d3b5c4df2771c9baee8de133ae3504d6"><pre>Tezt/long_tests: disable [block.*] tests in [block_validation.ml]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3aca1553759eca45af741f67f9d9a92693ba272e"><pre>Merge tezos/tezos!8714: Tezt/long_tests: disable failing [script_cache.ml] & [block_validation.ml] tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/667fa078e71e19cf61724104a2430ee4578efb98"><pre>doc: enable flag ODOC_WARN_ERROR</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4ba22fa8544dcd53884f749ffcddd044fc7e3987"><pre>doc: fix docstring errors</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1350663bf71241d0da3d0a1f7d35d16768471e47"><pre>doc: patch the doc of snapshotted protocols</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2057222aa66d90611199cd6140afc41a7d432391"><pre>doc: explain odoc errors in the coding guidelines</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0dba36124a7070652dc1baa43e08f28b0507cf3e"><pre>Merge tezos/tezos!8690: doc: fix remaining Odoc errors and enable ODOC_WARN_ERROR flag</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1b816acfb5f8692a69f12e27a29a3f7b69c65e8b"><pre>DAL/Node: ability to provide a different PoW at configure</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/43cc574911ed726b9db241d3e9ce0d49f6f04b59"><pre>DAL/Node: expose the worker instance in gs_interface</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f4fd151fb260d0d8aee22df9f5ddf818e99a6327"><pre>DAL/Node: expose the Monad module\'s interface</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9992a47ccae226c3e40fc6cf270ad5d4ded2d544"><pre>DAL/GS: extend the worker with facilities to monitor/log its events</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/189bf8831a8ca7e4beb3219a1950ae4019a58292"><pre>DAL/Node: implement logging for worker events</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/02f27d0f12b7f614c67047e028f54238c2ea6349"><pre>DAL/Node: expose GS logging module in Gossipsub</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d3e6c9b6607c373b9d68048e9e749f811803dce5"><pre>DAL/Node: enable worker events logging in daemon.ml</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/83ba21de1e468d5b12419b5bdc25edf91625e15d"><pre>Manifest: add needed deps to implement components interconnction</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6a16a21b87ac5fcbdd0805733abde8fd7b8cd499"><pre>DAL/Node: start implementhing GS and P2P interconnection: new connections</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eb59210722ec7504457def8d56761cf408bce3bd"><pre>DAL/Node: expose Interconnection module in Gossipsub wrapper</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/86ebac5597c62ec32bc9476e40fa4f6f79cfbcdf"><pre>DAL/Node: add the ability for activate to add points to the pool</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cc2f4c078db3dfb0c992d2aece3dfc1c7c78200a"><pre>DAL/Node: provide additional peers at P2P activation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/da90ea58e9e319c22dc9f159cc01649f02520e58"><pre>DAL/Node: enable GS and transport layer interconnection in daemon</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a3054cd8e679bd1a58c60f529abb63f9a34fe3ce"><pre>Tezt/lib_tezos: expose function listen_addr</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e678b442e68ef4c97b9c2e93b6b9881004ee9c13"><pre>Tezt/lib_tezos: Dal.init_config can now take a different PoW</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e88e962bce0079d958d1d800a6f65585ed391204"><pre>Tezt/lib_tezos: expose a function to read DAL nodes identity files</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/71d68f2cd31bc84808d6a2f46afe955b4a591b8c"><pre>Tezt/DAL: test for dal node p2p connection</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/22e96828bbbed57045c8b2aa2fbdfc38b3b507df"><pre>Merge tezos/tezos!8495: DAL/Node: forward new p2p connections events to GS</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/68b56f6edea328c9a117172c0d25b0cb5e281c9b"><pre>Client/Michelson: \`typecheck script\` can typecheck several scripts</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3b37d0bdd674fee7e634e4f36177b1a9205571d8"><pre>Client/Michelson: backport change on the typecheck script command</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6d4c5e525a153563bf050ad2740733ba45efb5bf"><pre>Tezt: support multiple scripts in {spawn_,}typecheck_script</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4a4412512f8c42ec8bd7728e9f84969037f6d65c"><pre>Tezt/Michelson: move iteration over typechecked scripts</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bd644872e8e7f22c10efe744da16fd296643fc51"><pre>Tezt/Michelson: all scripts typechecked in the same test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d5042654a5e8c3b42949d844d692301dcad0f416"><pre>Tezt: Regenerate regression traces</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/06c235080eeb229aa270674eb0066e7b80fd3db8"><pre>Tezt/Michelson/Typechecking: call \`typecheck script\` only once</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3b2341def241e8cc3502343cd4c3614b8e518414"><pre>Tezt: reset regression traces</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e0b5067bddb077de9f94e52f25364717a2504b07"><pre>Client/Michelson: add the --display-name flag to typecheck script</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3a4085db218f4b14f309496b73008848f65a48d5"><pre>Client/Michelson: backport to Mumbai and Nairobi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/080bbd81b58405cb7a4500f3813e8f9ddc017d28"><pre>Tezt/Michelson: add the ?display_names option to typecheck_script</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/839fc063f8ab1d05683fbfae71ca7c4fc062344e"><pre>Tezt/Michelson/Typechecking: use ~display_names in test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/24c322bda272cbe8dc4ff30095203526baa0bc2e"><pre>Tezt: reset regression traces</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a23e1ec52cf5a021f540c10ab486fb7ee3ca4c42"><pre>Client/Michelson/TCscript: compute name even without --display-names</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8bbd6e19881995a7b719faf7b06b1a64ee1b9635"><pre>Client/Michelson: backport to Mumbai and Nairobi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c9e856c7c90c4d8bd8c83331cab62d259b0a82ea"><pre>Client/Michelson: move display-names logic to print_typecheck_result</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f782cfc3700c28462796d2e7d1467e892538d583"><pre>Client/Michelson: backport to Mumbai and Nairobi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1f568fcb7b4791e9613c2c58e5948f1690a7eb94"><pre>Client/Michelson: change format of \"typecheck script\" output</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0cbe62f7a08b6f41fc06e217a34c8ebe256cad19"><pre>Client/Michelson: backport to Mumbai and Nairobi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ab7f29a320322c1496c36f1048291cadf679116e"><pre>Tezt: reset regression traces</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b3eef97a1588e98254fcd67ec9444baa6f13232a"><pre>Client/Michelson: display the name of ill-typed scripts</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/30960e3628ed59fd2275c9ad5699981eded622d9"><pre>Client/Michelson: backport to Mumbai and Nairobi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/afa836c6957f9f48b2a80247712ceeb8558aa855"><pre>Client/Michelson: fix numbering of literal scripts</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/00c6bb07761eebc13806a77694451977ac5c2477"><pre>Client/Michelson: backport to Mumbai and Nairobi</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/065b2af49b1585e0a5b0bd23edebb02f97eafed7"><pre>Tezt/Michelson: update error pattern for ill-typed scripts</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/36b7882ca06576d521f831e07f2c586d53682aa4"><pre>Tezt/Michelson: new numbering of literal scripts in hash script</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/75cc5fd1dd1eeb505fe46b205bfe0ddaa2f270cb"><pre>Merge tezos/tezos!8231: Client/Michelson: Typecheck several scripts</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1bcf62a6b9e6f8d84d009acf78a554560b60b7cd"><pre>DAC: get rid of useless LWt on certificate tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bc4bf6a4a0c520e29902ca4442758948a7350227"><pre>Merge tezos/tezos!8783: DAC: get rid of useless Lwt on certificate tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6dc2248642e3fdb85cffee46bdd9cf17726f1507"><pre>SCORU/Node: fix incorrect inbox for migration blocks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dc2fded6dcc2464bd081f23bf6feed4334e2cf09"><pre>SCORU/Node: rename incorrect migration_block to first_block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0af0d0bef4a768f05efe603bf21099c2d213ee66"><pre>Test: basic protocol migration for rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ba5a377e168f42f41134bd9bd926043d1972f43e"><pre>SCORU/Node: backport !8689 to Nairobi rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9ae2fb32d42a8bfae208ed8e239eab2c1f98be82"><pre>Merge tezos/tezos!8689: SCORU/Node: fix incorrect inbox for migration blocks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/39e5f943588c95db56b31c4d99caab6907186a26"><pre>DAL/Node: init the store with the GS worker</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c201d115b0e0bceb75e3b57e851264c2af88a9b4"><pre>DAL/Node: expose implem details of topic, message, and message_id</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8dc466f67738809a93c2d716b87bee45e83a4e82"><pre>DAL/Node: rework/fix worker events logging</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7dca3a2820ac945813a929a283618aebd714000d"><pre>DAL/Node: join the corresponding topics when adding a profile</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4dfd646d2b645c3f5aca09a669ea85e6461de887"><pre>Tezt/Dal: add a test for GS topic join</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ba2357d135d72ed91643dac36da0e8acf58b9781"><pre>Merge tezos/tezos!8681: DAL/Node: join corresponding topics when adding a profile</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/54e139a8b73f7263ea54890fdd6b851491a9fb73"><pre>DAL/Node: rework the GS/Transport interconnection interface</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/20627be072c29a97133cd1a76debf4ace43f229a"><pre>DAL/Node: add handlers to forward messages from/to GS to/from P2P</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9b1539ae0f22c9a7cddd7aa48b771808772c3e54"><pre>Tezt/DAL: test subscribe & graft</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fd754eceb3a2d4d91c1908f27541e279bcf3fa06"><pre>Merge tezos/tezos!8727: DAL/Node: send/recv p2p messages (test subscribe & graft)</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/6064e8b7052294305324ca1925c128414f3cd345...fd754eceb3a2d4d91c1908f27541e279bcf3fa06