### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -194,11 +194,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1684763926,
-        "narHash": "sha256-1pSTzogoCmZc7JB3VrFFgFoj5lNXIIWwkVReFVMHDT8=",
+        "lastModified": 1684842236,
+        "narHash": "sha256-rYWsIXHvNhVQ15RQlBUv67W3YnM+Pd+DuXGMvCBq2IE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "df448ffc5d244f52261d05894c5a96af7f3758a1",
+        "rev": "61e567d6497bc9556f391faebe5e410e6623217f",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1684811187,
-        "narHash": "sha256-DDcdd2Onu0lsLFT3eRT3v7BhmMMSqYEz1j+rPGLGFmc=",
+        "lastModified": 1684888584,
+        "narHash": "sha256-oxqTYT0iV78OiCO+gQJ4aRHpDaoNYiPFfLKMpV+crbc=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "6b95d7828c040324eaf2df0712e729e67842b3d9",
+        "rev": "81b9852308ce654ee0ded3eccf7fd0e6662cb9a4",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230523";
+    octez_version = "20230524";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/e1b28a58b2815061b70147544192338a3760f8db"><pre>Proto: add comments about derivarations of constants</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/649e3f32fdbf21f02908b1cd4dc6388bc22a263a"><pre>Proto: add comments about derivarations of constants</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a99fa659282db87189d6b6cb0cf3c4be4a805da8"><pre>Proto: add a comment about derivaration of constant</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cfbc82f61ba06d93bd402830ae8ef07e34d4491d"><pre>Proto: add comments about derivarations of constants</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4c0e898eab814a41cd574f18c2f53d8b45fba7b9"><pre>Proto: add comments about derivarations of constants</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1a5538a04f6517e3afd0abbcc579fd37a6ce724f"><pre>Merge tezos/tezos!8796: Proto: add names of the models from which some constants representing gas are derived as comments</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/63cceeb50b2b69883fafb5d3200403e72a6c857c"><pre>Shell: smart rollup commitment hashes as base hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6cf663e32d0ea67b32b3f94c3fa1c349f847412f"><pre>Shell: Smart rollup PVM state hashes as base hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/db6d5c9f11f2357939f65cbb2c0f3849febe0bac"><pre>Shell: Smart rollup merkelized payload hash as base hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/193078e3a20142a799059d9cb9bbaaa5e770c319"><pre>Shell: Smart rollup inbox hash as base hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ca8e430fee06a44ad308a1b065c9d328d48a6e0b"><pre>Environment: Encapsulate smart rollup address in Smart_rollup module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e2733036a6048c5367cac6ccd4eb73259c321311"><pre>Environment: expose smart rollup hash types</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ba167c1c530e86fd4ea29b11664bd0e48aef1929"><pre>Proto: use environment smart rollup commitment hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/afc56eadeed77439a3b71c63720e84ea35710677"><pre>Proto: use environment smart rollup state hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7d3130341dd8013782fc537725f7bba343c627a6"><pre>Proto: use environment smart rollup merkelized payload hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4da8746e90ca5d198512a0cdbaaf75dc3389c333"><pre>Proto: use environment smart rollup inbox hash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1caea173ed79efb5d3fd8aff3c5cc65eaae28334"><pre>Doc: Changelog</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fd6049c35fb5f8fc14b428295aa6aff94114995b"><pre>Merge tezos/tezos!8625: Proto/Env: expose smart rollup hash types through environment</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/87291e0871194c8c322bedcf51192626d5879687"><pre>DAL/crypto: check shard length</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/53b8b7453259a167be80bd93f9a6b3c605b3f71d"><pre>Merge tezos/tezos!8807: DAL/crypto: check shard length</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c705b129b1d20c41a208d9818570698c4c3d2c89"><pre>Wasmer: Delete module instance after use</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ad04240239d8c424e9c92d86043393636e8301b2"><pre>Wasmer: Delete export types after use</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1d6b5a764808e5e92068c095f8783c49b61a681a"><pre>Wasmer: Delete function types after use</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c371811982c71bea526674108eb3c3c7277def12"><pre>Wasmer: Delete memory type after use</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7d2982303be2bdea8cba3f25172f63556b29ccd4"><pre>Wasmer: Delete value types after use</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7650ffa947ab283277eae03d6db386e4d1f30d0c"><pre>Wasmer: Delete import types after use</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/01b12f2b342923531ce002a2ab8a91e17be78379"><pre>Merge tezos/tezos!8785: Wasmer: Squash instance leak</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fa1cf30746bf6cf207e0e1d6d11a6aceb02ae5d3"><pre>Lib_plompiler/Lang_core: remove useless primitive from interface</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/da083c086c22c63566f3ca6e2a2edb392089f461"><pre>lib_plompiler: remove redundant argument [variant] in Poseidon</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0ae35bb84ad7d800a93a089f11c38cb82e8eb546"><pre>Merge tezos/tezos!8837: Lib_plompiler: remove redundant argument [variant] in Poseidon</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ccfd23b3d9c5013f07e02ee8c5c55a08450a580c"><pre>Contrib: Add an essentially-empty contrib dir</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6451ad917866ad1de88e58aa39081ea2acdc20dd"><pre>Manifest: build without contrib</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3b8ae3edde849d3c279225be835541bf7a2b9aa4"><pre>Merge tezos/tezos!8771: Contrib: Add an essentially-empty contrib dir</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d698e970c068a33445442113d385b82402629833"><pre>Un-revert tezos/tezos!6787: Shell & plugins: bound the mempool by op count and total byte size</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/86aa7228b21f9678adebabff83f04531e5e7f181"><pre>Merge tezos/tezos!8814: Merge tezos/tezos!6787: Shell & plugins: bound the mempool by op count and total byte size</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/80e3db46b5ddf8d606f0ed536a8c88d0671d00b9"><pre>Doc/SORU: update the commitment period length</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bb2f93fbee00f7bb58e060f47532477b31bea2b1"><pre>Merge tezos/tezos!8780: Doc/SORU: update the commitment period length</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/030c3ca4ff3966fa89a75005f6235a6ea5688160"><pre>EVM/Execution: fix testing compilation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/13b882ca971e6316a12e8ccf00a7009424755ce0"><pre>Merge tezos/tezos!8832: EVM/Execution: fix testing compilation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/46f2757ef82f93d4519a61692bf7d33b243fc369"><pre>Docs: Fix typos and add more explanations for Smart Rollups</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4d93c620c59d48bd1c048ddd8908580870ea3d84"><pre>Merge tezos/tezos!8800: Docs: Fix typos and add more explanations for Smart Rollups</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/caa2d055d8a8ae7ed68e47826b31a30938d0cbb4"><pre>Wasmer: Delete value types after use</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/183841f9ecd5a5770d0d2eff4ccd892d63efc85e"><pre>V10: Add a new [Context_binary] module for rollups</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d127371fb7407989a4fff3f9b8f08fbd339ef75c"><pre>Merge tezos/tezos!8811: V10: Add a new [Context_binary] module for rollups</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3fc85e43ca4f871106bb666e98912923be5be4a3"><pre>EVM/Proxy: batched RPC requests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/aae9fbd32fd32726103c32d3108954ea779841c3"><pre>EVM/Proxy: update Tezt interface to handle batch request</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/32cd6f6850f881e9ed2f6914119d2a6e5b29bbfb"><pre>EVM/Proxy: test batch requests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ba8b9ce901d9b9a29bbaef01e2d73113fd5d88cc"><pre>EVM/Tezt: helper for setup evm and go past genesis</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/244ff3ded8fd910416ed508bd885de1987f635a5"><pre>Merge tezos/tezos!8808: EVM/Proxy: allow batching requests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/548b6c8801c0ce62f77258494379abc1b9d860ee"><pre>Proto: convert parameter ratio_of_frozen_deposits_slashed_per_double_endorsement to a percentage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fd0bdf1f5f168c2dace5936fa0589d45e0144138"><pre>Proto: convert parameter double_baking_punishment to a percentage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ea9cee4d4043f2dfd88a3361efd2f30fb5c39931"><pre>Proto/Slashing: factor punish_double_endorsing/baking</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e547dc4fe7599dfb0504ebfe60ae0ba1230ad740"><pre>Docs: add changelog entry</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/47dd7f358098b3e1d0510a0abda9ebae2d190ac3"><pre>Tezt: update regression output</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a848379e7f604e25a043ed1fd11bb9a02ed9f61a"><pre>Merge tezos/tezos!8753: Proto: convert slashing parameters to percentages</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c21db0ef9b7a9ad0c162fb1fb435f64394418e50"><pre>Build: silence ocamlopt warning \'no-cmx-file\'</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/08cce90a2deb537232a64087a86e1024a0d101c2"><pre>Merge tezos/tezos!8674: Build: silence ocamlopt warning \'no-cmx-file\'</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/211cd87ee99f15d6d7155eda2ec4d25c8bb3cde4"><pre>CODEOWNERS: fix spelling of @ACoquereau</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7e9cdf6ab1902f75dfbd9eb8539ed20a054cbadf"><pre>CODEOWNERS: add @MBourgoin and @victor-dumitrescu</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/faa3f05123ffaf4ee8e8dc59d8abcd2ac3ff87bc"><pre>CODEOWNERS: add owners for cryptography libraries</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3a963e38c9606d389a7e84159625d69f6bc075f8"><pre>Merge tezos/tezos!8835: CODEOWNERS: add @victor-dumitrescu and @MBourgoin</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cf131b2c5c6eac0059ef86b242e0f69bff3b59cf"><pre>Plompiler: rename rotate to rotate_right</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3c5eee7fdbbd4c8e673ba1232eced899a21536b9"><pre>Plompiler: more tests for rotate_right</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/00ecb4bd684693e55adc1401ddb85b07b2b6d0b4"><pre>Plompiler: add Bytes.input_bytes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/21d2225a46015c3aa1ad7b1accceeb4b910b63c0"><pre>Plompiler: clean tests with input_bytes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d7ffc83693bd23a0d21b201fa7fa212f1f16c213"><pre>Plompiler: clean test scalar_of_bytes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ae4863827d9ee65c9f86e0431134bbda0600ae82"><pre>Plompiler: add tests for Utils.bitlist</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bd92ab742b5a22d5851ef34258dd61ffa4311562"><pre>Plompiler: slow regressions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/678bece35cb64fbe208ab40e5d1e242ebdd6c426"><pre>Merge tezos/tezos!8777: Improvements to Plompiler.Bytes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cbd3a6938c31c20d97c69ad6ae2122d5be2c3e8f"><pre>Proto: Apply zero ticket migration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7589704877c3d05ee3a5ef3137f33c8d42e5b258"><pre>Merge tezos/tezos!8111: Proto: Apply zero ticket migration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/828f481af58744dfcdd64853fc9072496ff19458"><pre>Tezt/Snoop: addds the inference of bloomer</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2fc47d791ef456a82ba2494065dc7b4627c32146"><pre>Merge tezos/tezos!8802: Tezt/Snoop: adds the inference of bloomer</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0567d6f040bfd937785f66c13cf256a0680ae68f"><pre>Kernel SDK: allow builds of SDK as git dependency</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6dba66b142a45ba7d98e592d866f3ce1e4952135"><pre>Merge tezos/tezos!8834: Kernel SDK: allow builds of SDK as git dependency</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1c0ea3c18917d604d14f34cd4cba91ab254db768"><pre>Proto: Introduce rollup machines helpers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/81b9852308ce654ee0ded3eccf7fd0e6662cb9a4"><pre>Merge tezos/tezos!8815: Proto: Introduce rollup machines helpers</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/6b95d7828c040324eaf2df0712e729e67842b3d9...81b9852308ce654ee0ded3eccf7fd0e6662cb9a4