### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1684754342,
-        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "lastModified": 1684935479,
+        "narHash": "sha256-6QMMsXMr2nhmOPHdti2j3KRHt+bai2zw+LJfdCl97Mk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "rev": "f91ee3065de91a3531329a674a45ddcb3467a650",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1684888584,
-        "narHash": "sha256-oxqTYT0iV78OiCO+gQJ4aRHpDaoNYiPFfLKMpV+crbc=",
+        "lastModified": 1684971915,
+        "narHash": "sha256-w+6iJM/XIodKJ7KlvwHIczs8aa5h2gX4RjtYeFkPjSg=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "81b9852308ce654ee0ded3eccf7fd0e6662cb9a4",
+        "rev": "5c775cce769da7fc098ff43bc0f7edf433c9d6ee",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230524";
+    octez_version = "20230525";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/eda7cf09be7a8bfd663fb04c2047e49e65dc05cc"><pre>Scoru,Proto: init_genesis_info can take genesis_commitment.level</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6f26a7bf9328b37a94006da7e6dece72aac3f86e"><pre>Scoru,Proto: raw originate with given address</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a15a714bcef3b8a23d1c0326f1925f13ed8b4d34"><pre>Scoru,Proto: bootstrap smart rollup parameters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3d6714921bf2caefc15194bfa49f26b0cdd353a8"><pre>Scoru,Proto: produce genesis state of bootstrap smart rollups</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a5f76c85e1e571e39c4dabea1f8ba9f9abb6dcf1"><pre>Scoru,Tezt: parse smart rollup addresses in RPC</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8e3517f70f2e21acd3a8a539df72aa3dd0cbdef1"><pre>Tezt: parameters with bootstrap smart rollups</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a54e5715b298495cf360ffaeaa57fdd3952e23c6"><pre>Scoru,Tezt: test bootstrap smart rollups</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1c48236a5ccf4e9b18a545bc1a5ac0b83d06a69a"><pre>Scoru,Docs: add bootstrapped smart rollups to alpha changes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4ea91eec9194eec306169212050b1a2337f94e87"><pre>Scoru,Proto: typecheck bootstrap smart rollups</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5151769d9434d951492939e2d4f573b3f86354e2"><pre>Scoru,Proto: put [bootstrap/init_storage] after [sc_rollup_storage]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/89b7e228b10d6d6bedc2473b393f35b80dfe6c14"><pre>Merge tezos/tezos!8552: Scoru,Proto: specify bootstrap smart rollups in parameters</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/626c49a6a4f0f030ebf15c1ceadb98265d99ad22"><pre>proto: remove tx_rollup_bond_id</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e954d2d26899c70f33fecfd9cd9aac8521319183"><pre>proto: remove tx_rollup from alpha_ctxt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/257f725a1e4388a1bc932ef8af62e757e29727d5"><pre>proto: remove toru storage module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8a822ec526168cfd2ef37ac2b7e5c7ff6a6bb850"><pre>proto: remove toru gas and hash builder</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9d30ad0d8a7e8475cc2c9bacc3858288829c68ac"><pre>proto: remove toru storage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2616796d51de56d5871718415e20a6628c7db074"><pre>proto: remove rest of toru code</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d3843a994f2335996c5ec4f6928dc541ee195d24"><pre>proto/toru: remove burn function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1ee8ecb7ea473d55bd65f4b4ad522ff2e740cf95"><pre>Merge tezos/tezos!8466: proto: remove toru in protocol</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/efe8c11ada8752e289818afabe94e85dd87a2e9e"><pre>SORU: EVM: kernels stores contract address and proxy fetches it</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f1d11611f8a7b7273d607931fd0c9f3bc1a24788"><pre>SORU: EVM: test contract address in receipt and refacto</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/97423c6e697282330c70d603ce45027f74a3457e"><pre>Merge tezos/tezos!8696: SORU: EVM: store contract address in receipt</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4ab098dfe28601da5283010830c3c763f4fe7d64"><pre>Kernel SDK: fix cargo build instructions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/64e030293493423a780a8f0efd81004b131ffd95"><pre>Merge tezos/tezos!8843: Kernel SDK: fix cargo build instructions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1783c3b56ead95d8e7dce5e7836bb79346bb90bd"><pre>Proto/Alpha: refactor baking test and make test deterministic</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/69cea1ce866aaeb34ae2e26f7b3ff278d66d64d6"><pre>Proto/Alpha: add test for baking after full frozen deposit slash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ccbcf08a85a03fa0400bb6f7ceeeffd05174791b"><pre>Proto/Alpha: fix misordered error message</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3c50eb0c583a6f4f04e9fe04f4e8541067a45d86"><pre>Proto/Alpha: add storage of forbidden delegates</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0f45e872c45eca696f93453ae796a61c7769132c"><pre>Proto/Alpha: add set of forbidden delegates in raw context</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ed06a5a6147f6412a0c3a29dbc2941bb0fef1cd1"><pre>Proto/Alpha: add higher-level abstractions for forbidden delegates</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3a874b52420b94907031e2e214a57daa98ce7a82"><pre>Proto/Alpha: forbid delegates when deposits drops to/remain at 0xtz</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8e5e3878cc4d887ce48f7bb07eddd00407186222"><pre>Proto/Alpha: use the set of forbidden delegates in validate</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6c1dba0515e94921873dc0597578d8d9f84eeb4f"><pre>Proto/Alpha: load the forbidden delegate set at prepare</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9a0609300206435dfca326be8f2c3dc949c85510"><pre>Proto/Alpha: initialize forbiden_delegates set at stitching</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/aaed554e69d9619549a489b47ee3e91f5b09bf92"><pre>Tezt: update gas regression due to mockup mode calling stitching</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cdc9b173ec3ce10be5ac8212d5d362aae0bd4b2f"><pre>Changes: add entry</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/60c253b35f78356f27e72621b963b334fcfe4f6f"><pre>Merge tezos/tezos!8722: Optimize frozen deposits checks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/99c1274878c515d04a81032854072a6d7576e05b"><pre>PlonK/Circuit: sort range-checks indices</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8b95fc86f06c36e4b3a2316551c315ccf50c8e9d"><pre>PlonK/Main_protocol: update comment & some renamings</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6ac3a07dddc5e54607ccca2341d92f3d630e65bd"><pre>PlonK: automatic padding for range-checks bigger than circuit</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/56c8249f645848be694a674d9171ec100e56a4f8"><pre>aPlonK/Circuit: remove useless function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/777f59c1bbc1453ea6b468cfd9fbaf7f941ef81c"><pre>aPlonK: move map_end in PlonK.List</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/75dbc63a2289d20527e6ab6dfac70670ddd0b191"><pre>aPlonK/Main_protocol: minor clean</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/24f58bd7fd005121203b98bcac374a2baf119dac"><pre>aPlonK/Circuit: add comment</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/447ec129a89279d95ee7b00060d6d7e37ed31457"><pre>PlonK/Circuit: to_plonk takes cs_result instead of CS.t</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ab62b784ad50f908a2167a2e001fadbc005a5442"><pre>PlonK/Utils: add pad_answers function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/85de36fd2c07126c03bc60b2498fd787ecfddb0f"><pre>aPlonK/Main_protocol: add number of range-checked wires in prover_meta_pp</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6c94e3ee9663fc169c9518a10f97e8cec50c93ed"><pre>aPlonK/Circuit: pad_inputs takes nb_rc_wires as an argument</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6431bc7208c003615dd3ed2a9b30c7b21fdbed32"><pre>aPlonK: replace input_commit_infos by input_commit_funcs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ef7a38df2dd76f41f1adcfaad7506874a11927f6"><pre>aPlonK/Test_main_protocol: add test \'nb_proofs no pi\' for next wire</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2a23353dae17f88eb6cfd1268a4082292f6c40f4"><pre>PlonK/SMap: remove duplicate</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ea3551ccdf9ce11ed7751a08c6c17af2e8fddd4d"><pre>aPlonK/Circuit: clarify nb_batch handling</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/86fd0da0a6cdb56a460b2c8f724609aea0055abb"><pre>PlonK/SMap: prefix with proof idx by default</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b31e664fe515e71d0446a22f0f6bdac521314435"><pre>PlonK: commit RC_Z with wires</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0d0327c148bf6a71613e4b2281de9cce1af09235"><pre>aPlonK: add test for RC with more proofs in setup</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4fd2f65114826c414f7927b0f7d0c6ba5f5a8bff"><pre>aPlonK: change \'nb_batch\' for \'nb_batches\'</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dfb5e71d4f861fe197acc6ee2d28e079d969460c"><pre>PlonK: use the same randomness for Plookup, RC & Perm</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e026a3e2d591cc369118b15293ba569c382ecbe9"><pre>PlonK & aPlonK: promote slow regression</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1655eaf8335ec62e48e7b9d741b4f4acc7fbaf2e"><pre>Merge tezos/tezos!8730: PlonK & aPlonK/Range-checks : miscellaneous improvements</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4543e098c7797a09da43f31f68a8e8017e1ef937"><pre>Revert \"env: export Make_merkle_tree functor from Blake2B\"</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0729277b2d3cc06701069ff17e3b5bce1bf4c2d7"><pre>Merge tezos/tezos!8849: Environment: Revert \"env: export Make_merkle_tree functor from Blake2B\"</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/19dfcb267c246fe3dd37d5ccba9cc41c70c60be4"><pre>EVM/Proxy: read \`code\` from the rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/61f196900dcbc0f99b350ef2aa68f98a457b0eb8"><pre>EVM/Tests: test \`getCode\` in the deployment test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/04c89f5110a0076ec702a6f650e567cc3b94ea2d"><pre>EVM/Test: slight change of \`wait_for_application\` for consistency</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bd44d50286f5e2e8dc1b4c1d166243d1a020f67d"><pre>Merge tezos/tezos!8819: EVM/Proxy: read \`code\` from the rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5c058348928d90551efac615bd5953e40e07a434"><pre>lib_benchmarks_proto: add intercept benchmark of N_IComb</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9999683acfb38538c4e5e8be4258a8ff30856ea7"><pre>lib_benchmarks_proto: add intercept benchmarks of N_IComb_{get,set},N_IUncomb</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a2f4cde6512b4023b535a0ad7d8ac64efb6a5b53"><pre>lib_benchmarks_proto: add constant and intercept benchmark to N_IDupN</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9f72cd7044defa4cb143fc8c0d34c32543d5359b"><pre>Merge tezos/tezos!8799: Snoop: add intercept benchmarks of N_IComb, N_IComb_get, N_IComb_set, N_IUncomb, N_IDupN</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eddbc4b4b0eeb91e5f8f3ce8a1e1450ef28989eb"><pre>Deps: Consider js_of_ocaml-lwt as a dev dependency</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bafe73442a8d3383d278c225b45ecaf037e55bfe"><pre>Merge tezos/tezos!8851: Deps: Consider js_of_ocaml-lwt as a dev dependency</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b6b8e3f4873996f321fc2597650cbe3d9810c2cf"><pre>CI: Include the EVM kernel in the Docker images of master</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2bf1f6a9d0ac87c57b03f3efe49c1f2760c39177"><pre>Merge tezos/tezos!8670: CI: Include the EVM kernel in the debug docker image</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2bc356fe79b84ba15bc6c959911c4454a4a61db4"><pre>CODEOWNERS: add @MarcBeunardeau as octez merge team member</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b523b965090aed6b9fdb10119baac8b1a84fbcc9"><pre>CODEOWNERS : MarcBeunardeau replaces victor-dumitrescu for plonk</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dde138da72385a6269228f2fa80f80657f07a850"><pre>Merge tezos/tezos!8855: CODEOWNERS: add @MarcBeunardeau as Octez merge team member</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e66b25e8f655bcc919fc87551853e0adf318c090"><pre>Proto: Drop smart rollups’ origination proofs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8e19f008a4080e433c84469eb0da75b86c1f6690"><pre>Merge tezos/tezos!8817: Proto: Drop smart rollups’ origination proofs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9b7c78a09990c82366c9e5bc30352006706b5e6f"><pre>proto: add of_list function to build a Merkle_list</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e1a191723cc06e7db7e97364d6a67af6f0dba06b"><pre>Merge tezos/tezos!8853: proto: add of_list function to build a Merkle_list</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/63822a6a4bfbb08f79c84f18ae55e134a28e1bfa"><pre>Dac: observer query missing pages from DAC committee members</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4d4e4a3cd2bf0c02fc5e6f4b1cbedd17c359253b"><pre>Merge tezos/tezos!8747: Dac: observer downloads missing pages from committee</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e7bda4a8c564281619aa43110d4d747c761f58c5"><pre>Kernel/SDK: introduce Dac certificates (and encoding)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5c775cce769da7fc098ff43bc0f7edf433c9d6ee"><pre>Merge tezos/tezos!8797: [DAC/Kernel SDK] Encoding for certificates V0</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/81b9852308ce654ee0ded3eccf7fd0e6662cb9a4...5c775cce769da7fc098ff43bc0f7edf433c9d6ee