### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1684971915,
-        "narHash": "sha256-w+6iJM/XIodKJ7KlvwHIczs8aa5h2gX4RjtYeFkPjSg=",
+        "lastModified": 1685074283,
+        "narHash": "sha256-IbuY//LYw37Mq1cK3KgI1wBrmzBCNCqhZ9w2J5awwjc=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "5c775cce769da7fc098ff43bc0f7edf433c9d6ee",
+        "rev": "c1b7270d31dd37b9ae2ba99f899f42a51e7e82f1",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230525";
+    octez_version = "20230526";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/9a0e031956e5d5ae90896759d20fe20ba3461276"><pre>p2p/tezt: fix error propagation in forked process</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f703044341df23c638c6ec6f00967cfb1f6f65ca"><pre>Merge tezos/tezos!8650: p2p/tezt: fix error propagation in forked process</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/972838def0e406dcba30c142dd3cf0f3f1c07fe0"><pre>.gitlab-ci.yml: remove unused [image_template__alpine] template</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/849c436663cba3686caef87ac3323c6b6c4b576f"><pre>opam: bump opam-repository to get Alpine 3.17 images</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/513a47c2b6ab636a32d8f196426415c26c4fc429"><pre>docs: bump poetry version in doc test script</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f91c04f5eab89228facee1a81267418172c1a421"><pre>docs: document the used poetry version</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b191a97e51b605b6d3d8159e9ece9598b1f38788"><pre>rust: bump version from 1.60.0 to 1.64.0</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ebf320f48a4bce89793e01c20244007dcd0ad8ae"><pre>Merge tezos/tezos!8838: Bump opam-repository to images with Alpine 3.17 and Poetry 1.2.2</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3b2c47cbb6db0c2a74e6a362ec1bb162b0b9c2e6"><pre>Tests: run migration tests on Mumbai->Nairobi as well</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2fb38f1e416d666bc64d9f7e23c64f4c4aea6dc5"><pre>L2/Store: expose underlying Irmin store</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a65fd1c9a33bdc8bfaae6ce9b2e10d48a6fac6db"><pre>L2/Store: expose path of components</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/01126a486322cd70cc74b0f51f0d78855f6f0159"><pre>SCORU/Node/Store: iter on L2 blocks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/56f11a0207a77b03e0e148e31ae0a742845fbe33"><pre>SCORU/Node/Store: signature for versioned store</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c7d54b6702d442dcf80039de43472e996dd50f42"><pre>SCORU/Node/Store: two versions of the store module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/df1a32ac8b6dea590d8874d09a000f2aaddfb7d1"><pre>SCORU/Node: generic store migration logic</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/67828c196194f479a1892859a2c56aa1e965e5e6"><pre>SCORU/Node/Store: migrate messages from v0 to v1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d57e389e10d0cd1ce8720f3dcdb59025a73c0bdc"><pre>SCORU/Node/Store: migrate DAL data from v0 to v1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/12c90f0fb7366ae89b91d35702b9ea361c611af2"><pre>SCORU/Node: Backport !8676 to Nairobi rollup node, use store v1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0d931e1d53df5a3116e831f6c962e5e42b4b8289"><pre>SCORU/Node: Backport !8676 to Mumbai rollup node, use store v0</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fb71a7f4acded79c06da197da006ad25d98f2486"><pre>Doc: remove ocamldoc patch for removed file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/eda353dc0cbb214e46cd395933b774812e15b13e"><pre>SCORU/Node/Mumbai: Mumbai rollup node uses store v1</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/76dfbe00a0426d1fc913eadcda3b86f9c1fb3155"><pre>Merge tezos/tezos!8676: SCORU/Node: Store migrations</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d77aad52b107f1e217959125e04dd87e9efd85a5"><pre>SCORU/Node: version information for store</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3d26297070162ca8a9ef2ce5e72a90f4fd28a987"><pre>SCORU/Node: correct r/w typing constraint on context rollup address</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0c6d511a8fc888d8188cac4113ffa4fe0ca0e8c0"><pre>SCORU/Node: context versioning information</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/acc93d578c173fd93d626120eb28106ed3c41903"><pre>SCORU/Node/Nairobi: backport !8715 to Nairobi rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4e638a74a522220d093bcdf59adf05d66801919b"><pre>SCORU/Node/Mumbai: backport !8715 to Mumbai rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a7159728131d476ebf4246325844c62e06f4a968"><pre>Merge tezos/tezos!8715: SCORU/Node: store and context versioning information</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dc727670fe5ee39c56a8aa0c6e2c61f90451e29f"><pre>SCORU/Node: Store v2 with migrations</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9c9e5f1dcd2cf982864e7fa1d33f7303bf51eda1"><pre>SCORU/Node: use store v2 where messages don\'t have metadata</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ab0a3a4844285bc98d97a71772100cb3ee1bd5be"><pre>SCORU/Node: versioned encodings for commitments and inboxes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e8bda6ac0fb596f9f72f4906941452ea0959a3c4"><pre>SCORU/Node: Backport !8723 to Nairobi rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bf92275a03c7fc40917347506b485c18deed06e8"><pre>SCORU/Node: Backport !8723 to Mumbai rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/62613b7fd62308b305ce2c18351c9a97bc40bd67"><pre>Merge tezos/tezos!8723: SCORU/Node: Store v2 where messages don\'t have metadata and inboxes and commitments are versioned</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/90b1720da8349d59090e99232b0bdc0207e3078c"><pre>CI: handle missing variables gracefully in [docker_registry_auth.sh]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b954f0240675c733f93f711c1859bc82dd12f6d4"><pre>Merge tezos/tezos!8865: CI: handle missing variables gracefully in [docker_registry_auth.sh]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/068f23dde3eb2ae3136069048b365b811a3fc554"><pre>EVM/Kernel: store transaction object</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f516f3d035f7ffe03609e0ea33aaafcd46b0ad34"><pre>EVM/Proxy: asks kernel the transaction object</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3d42047fed7543e81c6b831fcb7cde763e2d7472"><pre>EVM/Tezt: test rpc getTransactionByHash</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/29f1e47c0f96d468c22de4b8bf7ff2430687a9ef"><pre>Merge tezos/tezos!8718: EVM: produce and read transaction object</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/63eddc9072eb2dfd1040466254bfca0a0adea012"><pre>Injector: Allow some duplicate operations in injector queue</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a459fea204230d338439e47974d2af9163a05e38"><pre>SCORU/Node: allow duplicate add_messges in injector</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9b9432467e99474ed1650ab07e7fdf4e47b7156a"><pre>SCORU/Tezt: test duplicate add_messages in injector</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f14fe4970ed6f2f8ba776c7160d1cee173bdee44"><pre>Merge tezos/tezos!6578: SCORU/Injector: Allow duplicate operations in injector\'s queue</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1e2d1f22d2f7b11fe6af997bb12c834e05eed785"><pre>DAC: Move \`handle_get_missing_page\` to \`Observer\` module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/724fab118373c70d8329e220fb9e4d4f9ed07d36"><pre>DAC: Introduce \`RPC_handlers\` module</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/990c8bf61c71f5639212decebff1c1b8cec70aa1"><pre>DAC: Move health handlers to \`RPC_handlers\`</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bc6a95654914789bf6d51d0b71a62c600d8274d7"><pre>DAC: Move handlers common to \`V0\` and \`V1\` to \`RPC_handlers\`</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1796bfc7ed06966f98aafeda646baf47addee454"><pre>DAC: Move \`V0\` handlers to \`RPC_handlers\`</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a3b1ff6ce6565408d302510f7a783f07dd5a92bc"><pre>DAC/RPC_server: Encapsulate \`V1\` API</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3cee5d170724bb9b8327fb3048c26d6e28eb88fd"><pre>DAC/RPC_server: Encapsulate \`V0\` API</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2a2b8c07c91bfca127da530166c8f47cb7991ca9"><pre>Merge tezos/tezos!8764: DAC: \`RPC_server\` code organization reflects code versioning</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2d9166573c6b566b9d161b9abb58cca28a5d0f49"><pre>Scoru: Use immutable CBV internally in the original CBV</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f832884d48ca51df30e38459d1fbd169a0e27c18"><pre>Merge tezos/tezos!8713: Scoru: Use immutable CBV internally in the original CBV</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bc971b76bf3871cc5ca2ad2f2f8691c40e8804d9"><pre>Tezt: Keep the standard input of daemons</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c43740840bed1a788e3d63ad18883842388b4ecc"><pre>Merge tezos/tezos!8873: Tezt: Keep the standard input of daemons</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/79f2a619c5e2414d9132e50cb5fb19075509ad79"><pre>Dac: add experimental disclaimer on node start up</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/08b734383ab2e9cef8a6e2cac547610bf5e12e68"><pre>Merge tezos/tezos!8863: Dac: add experimental disclaimer on node start up</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a4d9f4a3a9d8cccd79a6ef0092dddb938c043027"><pre>Deps: install sapling parameters files via opam</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f7f01e78b918a3b45ac8d69e017e226c55b16bcb"><pre>Merge tezos/tezos!8601: Deps: install sapling parameters files via opam</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6337c7a75246e5d46c88d0a05ecc1da0211f0f32"><pre>DAL/GS: add message_id in Message.valid</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4031712a72f85cf77d94d801f02f9821b3bc7ffb"><pre>DAL/GS: provide Message.valid via a hook</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c69a8cc06e62cfaddd0b4455a399fdca6a9c6bd9"><pre>DAL/GS: export Validate_message_hook.set in gossipsub.ml*</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0a15e9914331e179cc204b43a9063130b5b8d87f"><pre>DAL/Node: add an event for the case where message validation fails</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fd65b58909ce5b19407010bd849290f47bbc44e0"><pre>DAL/Node: implement GS messages validation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dc0ea0ff416a90dad903f99322bb99e52c588766"><pre>Tezt/DAL: introduce helper function connect_nodes_via_p2p</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2e6bc93b4b194ff084957222578708ce3037067a"><pre>Tezt/DAL: use the connect_nodes_via_p2p helper function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2d441ac06ee89f3bb135b6dbb2df240cc0e40264"><pre>Tezt/DAL: introduce a helper function nodes_join_the_same_topics</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7badc92379ba7a97ea3eec4b8ff59555717f30e3"><pre>Tezt/DAL: use the nodes_join_the_same_topics helper in msg exchange test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6a84eacd8aecb4177e58ece208f17aeee39a0ece"><pre>Tezt/DAL: rename main test to test_dal_node_gs_valid_messages_exchange</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7f741b83beae3773257852a4fa08b18cfecdb28e"><pre>Tezt/DAL: add custom tags for GS tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ddc4814dc68697513eda6efd1d9611c4bada2cf1"><pre>Tezt/DAL: add a helper waiters_publish_shards</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8d2dc73a4860f261231554ba48305220997bbbcd"><pre>Tezt/DAL: introduce a helper function waiter_receive_shards</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/674336d186f54b131b8b4b489bb55654678c3109"><pre>Tezt/DAL: add a helper waiter_successful_shards_app_notification</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/31ca3877d53d554cd161d6db19aec9a7c51dd438"><pre>Tezt/DAL: use helpers in test_dal_node_gs_valid_messages_exchange</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/331ba2db898c38036ef1e7b6e481ff3c99634985"><pre>Tezt/DAL: refactor test to reuse it for invalid messages exchange</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/24d48d7066929a20a0c6ee6cba9cb21b33214a95"><pre>Tezt/DAL: add test_dal_node_gs_invalid_messages_exchange test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/af684c99ed9264c499da8ec776a869f9add117ab"><pre>Merge tezos/tezos!8775: DAL/Node: validate GS messages (version 1)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d2ad1c52b28841aabde5e7fb9fc3f5b48e74ec0a"><pre>Benchmark: fixes printing of solution in text (#5692)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4e3a405702df8ca28251066871a76beac42e0a2f"><pre>Merge tezos/tezos!8825: Benchmark: fixes printing of solution in text (#5692)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/366e7d42c5b39efedc5ab4832ab3880131ee118b"><pre>Benchmarks_proto: adds comments for the constructor lists which affect the workload encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bbd351d22d255ec16cce270cfeb5c1cf55f3bafb"><pre>Merge tezos/tezos!8788: Benchmarks_proto: adds comments for the constructor lists which affect the workload encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/5b0e7fee59351d2f62a55cf15360c0879c1a7850"><pre>lib_benchmark: Add warning if the same model is registered</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2cdba7660873ed150a0f8fee78caeb5b38d48874"><pre>snoop: Change conflicted models names</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/abe069756dd0efe1c0a2afb83ce8ed132204bffd"><pre>lib_benchmark: modify the model equality check</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c1b7270d31dd37b9ae2ba99f899f42a51e7e82f1"><pre>Merge tezos/tezos!8604: Resolve conflicted model names</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/5c775cce769da7fc098ff43bc0f7edf433c9d6ee...c1b7270d31dd37b9ae2ba99f899f42a51e7e82f1