### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1685168767,
-        "narHash": "sha256-wQgnxz0PdqbyKKpsWl/RU8T8QhJQcHfeC6lh1xRUTfk=",
+        "lastModified": 1685383865,
+        "narHash": "sha256-3uQytfnotO6QJv3r04ajSXbEFMII0dUtw0uqYlZ4dbk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e10802309bf9ae351eb27002c85cfdeb1be3b262",
+        "rev": "5e871d8aa6f57cc8e0dc087d1c5013f6e212b4ce",
         "type": "github"
       },
       "original": {
@@ -194,11 +194,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1684842236,
-        "narHash": "sha256-rYWsIXHvNhVQ15RQlBUv67W3YnM+Pd+DuXGMvCBq2IE=",
+        "lastModified": 1685361114,
+        "narHash": "sha256-4RjrlSb+OO+e1nzTExKW58o3WRwVGpXwj97iCta8aj4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "61e567d6497bc9556f391faebe5e410e6623217f",
+        "rev": "ca2fdbf3edda2a38140184da6381d49f8206eaf4",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1685121291,
-        "narHash": "sha256-KZNeZBjqafwV/fmgwLsnGyZphCM7E2C4SMG9SQK0+tQ=",
+        "lastModified": 1685418275,
+        "narHash": "sha256-ey0tYFroFnQ7Z3SdCWL2gGURqVazJ2CsSwQGdKXhPbE=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "a317741fb9aeb54b1be027819edb89700f7ee5af",
+        "rev": "abe16049aa0be5f0f10dbb5478193c646a9c8d50",
         "type": "gitlab"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230529";
+    octez_version = "20230530";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/78e1f9ed192052370f1c96fd56ffd605480d5939"><pre>SORU: EVM: PROXY: initialize chunker</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/24ba80fafb04a22760efda6909d59046c932ab91"><pre>SORU: EVM: exe for chunking tx</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4e6a392fb959af50f391b7c2e8e6863e2d23fb5e"><pre>SORU: EVM: address 0 if none given</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/85a4f881760da9ffab803071b74ab328470961c3"><pre>EVM: pb dune build @doc</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6296903a603c03d82623170f41e382a732793119"><pre>Merge tezos/tezos!8781: SORU: EVM: executable to chunk transaction for the kernel</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a646175bf9353db873cf30348d8349522817f7a2"><pre>Benchmark: adds py*.mli</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b2c4b3c2710438562b60ba3a18733b0fbd2821ca"><pre>Benchmark: adds py*.mli and removes unused and duplicated functions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cccb032d50ff40564a2e7f31cdfdacb3ad7912e4"><pre>Benchmark: removes Pytools.import_noce</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/43ed47f9ee857ab8d9f656ca3a3f7b5ad12ea784"><pre>tries to catch => catches</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/99c9e433f71c36d89100c88aea12d2b3094554ae"><pre>Merge tezos/tezos!8539: Benchmark: adds py*.mli</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/af4a950014801bad4fc73e05219d8d03a935ae00"><pre>Tezt: adds codegen to snoop/main.exe</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/75517d332649ee6523b82b5f87ad66a541663e36"><pre>removes unnecessary comment</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/abe16049aa0be5f0f10dbb5478193c646a9c8d50"><pre>Merge tezos/tezos!8665: Tezt: adds codegen to tezt/snoop/main.exe</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/a317741fb9aeb54b1be027819edb89700f7ee5af...abe16049aa0be5f0f10dbb5478193c646a9c8d50