### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1685457039,
-        "narHash": "sha256-bEFtQm+YyLxQjKQAaBHJyPN1z2wbhBnr2g1NJWSYjwM=",
+        "lastModified": 1685546676,
+        "narHash": "sha256-XDbjJyAg6odX5Vj0Q22iI/gQuFvEkv9kamsSbQ+npaI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80717d11615b6f42d1ad2e18ead51193fc15de69",
+        "rev": "6ef2707776c6379bc727faf3f83c0dd60b06e0c6",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1685499599,
-        "narHash": "sha256-LFfBvba06er7zbVJCEFj5POqtlGt5z1ttIrxBeM/8ro=",
+        "lastModified": 1685563989,
+        "narHash": "sha256-KrhmRsPREX2ArUoetJjHrOVTBJeeScu+T1QtgadVXmc=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "a948d637d5506619e41573e1a1df65ab5f84faf0",
+        "rev": "0da9b68ef1b425a548e996e94c21dccd1213df93",
         "type": "gitlab"
       },
       "original": {
@@ -276,11 +276,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685455340,
-        "narHash": "sha256-yv72jHfXgSLrq/gDPZQfDmKJLEibz2wbCeimr6b4NF4=",
+        "lastModified": 1685519364,
+        "narHash": "sha256-rE9c9jWDSc5Nj0OjNzBENaJ6j4YBphcqSPia2IwCMLA=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d352b2b1a46164443aa114bd29d8d208d8a9bd0",
+        "rev": "6521a278bcba66b440554cc1350403594367b4ac",
         "type": "github"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230531";
+    octez_version = "20230601";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/d612f8a1ffca9c89e0ab89863ee748fee691e466"><pre>Alcotezt: port [bls12-381-signature/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4d1c65bcac8ef85999b0a904f891a197d73805c5"><pre>Alcotezt: disable js tests for bls12-381-signature/test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cb38cea4d0dd43b10932db20a78ce1f740fe44e9"><pre>Merge tezos/tezos!8878: Alcotezt: port [bls12-381-signature/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/59689416cdb7d8e62a36e533feeef2e7c91c579b"><pre>proto: move version_value to constants_repr</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/21835701578bda7180aef803f37cba19c5309262"><pre>Merge tezos/tezos!8867: proto: move version_value to constants_repr</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ed016aeba5d39f0221ee41be3b8e7860a376c6de"><pre>Tezt: Allow to import a snapshot with no checks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0a088fedba648040c5bcd34cf9b6fc4407331041"><pre>Merge tezos/tezos!8921: Tezt: Allow to import a snapshot with no checks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f4677174f0773e4e0320670fd50f66bc7a51b1e9"><pre>lib_plompiler csir: change the number of wires 5 -> 6</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/718c7f7f8c5d8bc658334bfcedc6ab65409296a2"><pre>lib_plompiler circuit result: introduce [unscalar] and [to_s]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/789769ae77b9354333bcd46384a44e6b8183cda6"><pre>lib_plompiler lib_plonk: implement gadgets for modular addition</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/25e80cb6d11de123f9c1229389b2eb4626a6bbae"><pre>lib_plompiler lib_plonk: introduce [ArithMod25519]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/846c189650799c2ef0b4ff26c4d0c425730d8d74"><pre>lib_plonk: test modular addition (in plonk and plompiler)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ce3d6a0a11437d57c8f1c868ab70e4b917b2cd6e"><pre>proto_alpha dummy_zk_rollup: reduce nb of batches in test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3d8dd5f73a4113d73c0b78ffe1d0bb3d300783ed"><pre>Merge tezos/tezos!8706: Efficient non-native modular addition in PlonK</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/818732788751ef113df2584c375d23dc0a616edb"><pre>Manifest: fix pretty-printing of s-exprs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/599c4b92551d5d6aad869de5106c2dde86c7d8dd"><pre>Merge tezos/tezos!8922: Manifest: fix pretty-printing of s-exprs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dbbb31927477bb9f96008d00b0f076dd3bbaa4d6"><pre>Proto: Add Reward_coeff to Storage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6941db18ec63f2870d26c9cafab540a833aaf85a"><pre>Proto: Add reward coefficient in context</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9fdbd44a54dbf7ba3235032ecff878b5d3b101d6"><pre>Proto: Add module for Adaptive Inflation Storage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/de2829712d4f3baea6f7aeb183cae9f9a47e0ff0"><pre>Proto: Use reward coeff in reward calculations</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/926d0eea2fb47d0dbe851b53cee7ed15bfad527f"><pre>Proto: Add dummy coeff computation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9deb61e3505f1fde8cc443ddcfa2213d5d4574ab"><pre>Proto: Update Adaptive Inflation Storage at end of cycle</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8e443f11f493502b8150a66208a92054a5357b27"><pre>Proto: Compute new rewards under Adaptive Inflation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cd91128f88644d892e07120a63f1440ba520927b"><pre>Proto: init reward coeff in context</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/613c7e20cda1de6662dd16fae1c73f87826f63cc"><pre>Proto/test: add Adaptive Inflation reward coeff test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3a12c4bfee3ceb5f862250bc4f2e9dd302c790a0"><pre>Merge tezos/tezos!8860: Proto/AI: compute new reward function under Adaptive Inflation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/469bdfe47f3d9a456b69fbcfeef9706ce79e7e98"><pre>EVM/Proxy: add web3_clientVersion RPC</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/784346832b591dbf6c60a8bf2c033102b0ce5937"><pre>EVM/Test: test rpc \`web3_clientVersion\`</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/68807e87689c574aeceb5cffe868ee39bb7119c4"><pre>Merge tezos/tezos!8821: EVM/Proxy: add web3_clientVersion RPC</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6ec64df54e7a088b9fbce1e3bb67f4c236a920f5"><pre>External validator: fix handshake documentation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e548fd8543aee75a1e644aabbab8f2432b09d7a8"><pre>Merge tezos/tezos!8925: External validator: fix handshake documentation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1e567d3430c33fb8b075db60f85808681e5ad74e"><pre>EVM on WASM: static call for the EVM</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fd3ffacd6aab08031ed209d38e04694363099ca8"><pre>Merge tezos/tezos!8711: EVM on WASM: implement STATICCALL</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e8cfffdd97815234b219a1d2d6a63d7778737bdb"><pre>EVM/Proxy: depends on rlp</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/20e9e2dac8580d4220765442377f730918f51459"><pre>Merge tezos/tezos!8911: EVM/Proxy: depends on rlp</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e0be750cdf914db72390ff011f0d016a504b0b1d"><pre>CI/Scripts: move [tezt/records/update.ml => scripts/ci/update_records]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/198a18af32a3e21a7c636a0b00d94d48f852a02c"><pre>[scripts/ci/update_records/update.ml]: fix usage string</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/edf90086dfd5ac8361dcabc6c13b75c62d1da8aa"><pre>[scripts/ci/update_records]: extract [tezt_gitlab] library</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fffe99995ccb94e7f8257cb378e74316823e9b01"><pre>scripts/ci: Move [get_last_merged_pipeline => Tezt_gitlab.Gitlab_util]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cf95201ab1cf586f4625b4a255065d8127127e96"><pre>scripts/ci: add [download_coverage] script</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0978ce10ea73dfb8bdc2bb386c46c9997c885919"><pre>CI: do not run [unified_coverage] in marge-bot pipelines</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dd2417ca163d45eda0b5e66e666ad3a78a5a4dfa"><pre>Merge tezos/tezos!8600: CI: move unified coverage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/affd36fccd6538d1491ff1db3eb77aed9bd98e3f"><pre>EVM/Kernel: store genesis transactions objects</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cc3cd88020f5405deb47c87974c923d9c898f307"><pre>EVM/Kernel: test transactions in the genesis block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fa0e5934737e3048e4ada1a0ea6249381431c884"><pre>Merge tezos/tezos!8909: EVM/Kernel: store the transaction objects for the genesis block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0ff78a5f351774b0320b7a21e3a840a14f45c252"><pre>environment: introduce environment_protocol_T_V10</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2ad28481d53c36d83d5d0284b5b46d40099e14fa"><pre>environment: introduce encoding_with_legacy_attestation_name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9b50918d43cd1e8aca17ade3c977728e79dcdac3"><pre>proto: use lifted protocols when using block_services functor</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/61fef700acca2cda61253ac7e06b491cb3989b1f"><pre>lib_shell: block_services requires encoding with legacy attestation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bd785d7fd962bf29e912835d71618c4c08fa92f4"><pre>shell: use encoding with legacy attestation name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d3945cf53ddacf6c72affa0efaec1b3c271356bc"><pre>lib_mockup: use encoding with legacy attestation name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cfce4146f3aaada0a4bb2d1f0f2a5e834a0ee910"><pre>proto_alpha: non legacy encoding use encoding with attestation name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2d547346a7328675544b15e5dc164e75a65c393a"><pre>Changes: add env entry for encoding with legacy attestation name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a5620c1f9ad333fc9c8024361a26a2bca5fde998"><pre>Merge tezos/tezos!8620: introduce encoding_with_legacy_attestation_name functions in environment</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4ebc09d8b71a39f03a48f182e0a309cb95988b9d"><pre>WASM/Debugger: fix \`step inbox\` tick and level counting</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9c4b572a673e29381f36082366380e0169173505"><pre>Merge tezos/tezos!8703: WASM/Debugger: fix \`step inbox\` tick and level counting</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4ec2294a3ff809d3efd663c271be474d3fe5c2ce"><pre>Injector: fix operation\'s uniqueness</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1a39b3c8960cbde4d9aea5956ff93fd375f6f2ae"><pre>Tezt: revert invalid test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/56a835f83124fc5d1dfd255aeaabbf76f3aade5d"><pre>Merge tezos/tezos!8929: Injector: fix operation\'s uniqueness</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ee6850c5ae7113dd4728dc7692e79cdae2b9396a"><pre>Scoru,Node: read durable storage after simulation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ba8112a296dcd82ee6d5444ba6ed01579f06640a"><pre>SCORU/Node/Mumbai: backport !8869</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c9a171ab63405bc73ebfd72665ee9ea470ffb83f"><pre>SCORU/Node/Nairobi: backport !8869</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3d6a349fb8fa6e2cb1a94f747346e03e43acd996"><pre>Merge tezos/tezos!8869: Scoru,Node: read durable storage after simulation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/26434f51e0c7a4085c1786dbe8076d74dbf902fc"><pre>p2p: reduce log default verbosity for some tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/18aa39299e763dc6d602413708c8ceef43aacdf1"><pre>Merge tezos/tezos!8636: p2p: reduce log default verbosity for some tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6e257a135468c2de75613d58427f8c77176dfa52"><pre>Scoru: remove commitment from cement operation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0da9b68ef1b425a548e996e94c21dccd1213df93"><pre>Merge tezos/tezos!8850: Scoru: remove commitment from cement operation</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/a948d637d5506619e41573e1a1df65ab5f84faf0...0da9b68ef1b425a548e996e94c21dccd1213df93