### PR TITLE
Update sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1685457039,
-        "narHash": "sha256-bEFtQm+YyLxQjKQAaBHJyPN1z2wbhBnr2g1NJWSYjwM=",
+        "lastModified": 1685662779,
+        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80717d11615b6f42d1ad2e18ead51193fc15de69",
+        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
         "type": "github"
       },
       "original": {
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1684252411,
-        "narHash": "sha256-4T89zvNljrrErlsiWG/u9/AY3qj6KXeiaa/Mpx0SEsk=",
+        "lastModified": 1685771919,
+        "narHash": "sha256-3lVKWrhNXjHJB6QkZ2SJaOs4X/mmYXtY6ovPVpDMOHc=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "2e0a633344489b3171afe136b820b4602f9d1807",
+        "rev": "95e2220911874064b5d809f8d35f7835184c4ddf",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1682879489,
-        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "lastModified": 1685564631,
+        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
         "type": "github"
       },
       "original": {
@@ -155,11 +155,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1685383865,
-        "narHash": "sha256-3uQytfnotO6QJv3r04ajSXbEFMII0dUtw0uqYlZ4dbk=",
+        "lastModified": 1685836261,
+        "narHash": "sha256-rpxEPGeW4JZJcH58SQApJUtJ7w78VPtkF6Cut/Pq6Kg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e871d8aa6f57cc8e0dc087d1c5013f6e212b4ce",
+        "rev": "dd4982554e18b936790da07c4ea2db7c7600f283",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
     "tezos_trunk": {
       "flake": false,
       "locked": {
-        "lastModified": 1685499599,
-        "narHash": "sha256-LFfBvba06er7zbVJCEFj5POqtlGt5z1ttIrxBeM/8ro=",
+        "lastModified": 1685884074,
+        "narHash": "sha256-jzpKY/toQWpymlj7U0s55eV5/xiavPrh/oQwTCmiBss=",
         "owner": "tezos",
         "repo": "tezos",
-        "rev": "a948d637d5506619e41573e1a1df65ab5f84faf0",
+        "rev": "bdd90c13bc93379d7d10eab02235f41807f09963",
         "type": "gitlab"
       },
       "original": {
@@ -276,11 +276,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685455340,
-        "narHash": "sha256-yv72jHfXgSLrq/gDPZQfDmKJLEibz2wbCeimr6b4NF4=",
+        "lastModified": 1685519364,
+        "narHash": "sha256-rE9c9jWDSc5Nj0OjNzBENaJ6j4YBphcqSPia2IwCMLA=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d352b2b1a46164443aa114bd29d8d208d8a9bd0",
+        "rev": "6521a278bcba66b440554cc1350403594367b4ac",
         "type": "github"
       },
       "original": {

--- a/nix/trunk/default.nix
+++ b/nix/trunk/default.nix
@@ -5,7 +5,7 @@
 }: let
   overlay = import ./overlays.nix;
   version = {
-    octez_version = "20230531";
+    octez_version = "20230605";
     src = inputs.tezos_trunk;
   };
 in {


### PR DESCRIPTION
:robot_face: Updating sources to the latest version.

#### New commits on tezos/tezos Trunk
* <a href="https://gitlab.com/tezos/tezos/-/commit/d612f8a1ffca9c89e0ab89863ee748fee691e466"><pre>Alcotezt: port [bls12-381-signature/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4d1c65bcac8ef85999b0a904f891a197d73805c5"><pre>Alcotezt: disable js tests for bls12-381-signature/test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cb38cea4d0dd43b10932db20a78ce1f740fe44e9"><pre>Merge tezos/tezos!8878: Alcotezt: port [bls12-381-signature/test]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/59689416cdb7d8e62a36e533feeef2e7c91c579b"><pre>proto: move version_value to constants_repr</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/21835701578bda7180aef803f37cba19c5309262"><pre>Merge tezos/tezos!8867: proto: move version_value to constants_repr</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ed016aeba5d39f0221ee41be3b8e7860a376c6de"><pre>Tezt: Allow to import a snapshot with no checks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0a088fedba648040c5bcd34cf9b6fc4407331041"><pre>Merge tezos/tezos!8921: Tezt: Allow to import a snapshot with no checks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f4677174f0773e4e0320670fd50f66bc7a51b1e9"><pre>lib_plompiler csir: change the number of wires 5 -> 6</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/718c7f7f8c5d8bc658334bfcedc6ab65409296a2"><pre>lib_plompiler circuit result: introduce [unscalar] and [to_s]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/789769ae77b9354333bcd46384a44e6b8183cda6"><pre>lib_plompiler lib_plonk: implement gadgets for modular addition</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/25e80cb6d11de123f9c1229389b2eb4626a6bbae"><pre>lib_plompiler lib_plonk: introduce [ArithMod25519]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/846c189650799c2ef0b4ff26c4d0c425730d8d74"><pre>lib_plonk: test modular addition (in plonk and plompiler)</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ce3d6a0a11437d57c8f1c868ab70e4b917b2cd6e"><pre>proto_alpha dummy_zk_rollup: reduce nb of batches in test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3d8dd5f73a4113d73c0b78ffe1d0bb3d300783ed"><pre>Merge tezos/tezos!8706: Efficient non-native modular addition in PlonK</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/818732788751ef113df2584c375d23dc0a616edb"><pre>Manifest: fix pretty-printing of s-exprs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/599c4b92551d5d6aad869de5106c2dde86c7d8dd"><pre>Merge tezos/tezos!8922: Manifest: fix pretty-printing of s-exprs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dbbb31927477bb9f96008d00b0f076dd3bbaa4d6"><pre>Proto: Add Reward_coeff to Storage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6941db18ec63f2870d26c9cafab540a833aaf85a"><pre>Proto: Add reward coefficient in context</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9fdbd44a54dbf7ba3235032ecff878b5d3b101d6"><pre>Proto: Add module for Adaptive Inflation Storage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/de2829712d4f3baea6f7aeb183cae9f9a47e0ff0"><pre>Proto: Use reward coeff in reward calculations</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/926d0eea2fb47d0dbe851b53cee7ed15bfad527f"><pre>Proto: Add dummy coeff computation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9deb61e3505f1fde8cc443ddcfa2213d5d4574ab"><pre>Proto: Update Adaptive Inflation Storage at end of cycle</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/8e443f11f493502b8150a66208a92054a5357b27"><pre>Proto: Compute new rewards under Adaptive Inflation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cd91128f88644d892e07120a63f1440ba520927b"><pre>Proto: init reward coeff in context</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/613c7e20cda1de6662dd16fae1c73f87826f63cc"><pre>Proto/test: add Adaptive Inflation reward coeff test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3a12c4bfee3ceb5f862250bc4f2e9dd302c790a0"><pre>Merge tezos/tezos!8860: Proto/AI: compute new reward function under Adaptive Inflation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/469bdfe47f3d9a456b69fbcfeef9706ce79e7e98"><pre>EVM/Proxy: add web3_clientVersion RPC</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/784346832b591dbf6c60a8bf2c033102b0ce5937"><pre>EVM/Test: test rpc \`web3_clientVersion\`</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/68807e87689c574aeceb5cffe868ee39bb7119c4"><pre>Merge tezos/tezos!8821: EVM/Proxy: add web3_clientVersion RPC</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6ec64df54e7a088b9fbce1e3bb67f4c236a920f5"><pre>External validator: fix handshake documentation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e548fd8543aee75a1e644aabbab8f2432b09d7a8"><pre>Merge tezos/tezos!8925: External validator: fix handshake documentation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1e567d3430c33fb8b075db60f85808681e5ad74e"><pre>EVM on WASM: static call for the EVM</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fd3ffacd6aab08031ed209d38e04694363099ca8"><pre>Merge tezos/tezos!8711: EVM on WASM: implement STATICCALL</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e8cfffdd97815234b219a1d2d6a63d7778737bdb"><pre>EVM/Proxy: depends on rlp</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/20e9e2dac8580d4220765442377f730918f51459"><pre>Merge tezos/tezos!8911: EVM/Proxy: depends on rlp</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e0be750cdf914db72390ff011f0d016a504b0b1d"><pre>CI/Scripts: move [tezt/records/update.ml => scripts/ci/update_records]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/198a18af32a3e21a7c636a0b00d94d48f852a02c"><pre>[scripts/ci/update_records/update.ml]: fix usage string</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/edf90086dfd5ac8361dcabc6c13b75c62d1da8aa"><pre>[scripts/ci/update_records]: extract [tezt_gitlab] library</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fffe99995ccb94e7f8257cb378e74316823e9b01"><pre>scripts/ci: Move [get_last_merged_pipeline => Tezt_gitlab.Gitlab_util]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cf95201ab1cf586f4625b4a255065d8127127e96"><pre>scripts/ci: add [download_coverage] script</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0978ce10ea73dfb8bdc2bb386c46c9997c885919"><pre>CI: do not run [unified_coverage] in marge-bot pipelines</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dd2417ca163d45eda0b5e66e666ad3a78a5a4dfa"><pre>Merge tezos/tezos!8600: CI: move unified coverage</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/affd36fccd6538d1491ff1db3eb77aed9bd98e3f"><pre>EVM/Kernel: store genesis transactions objects</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cc3cd88020f5405deb47c87974c923d9c898f307"><pre>EVM/Kernel: test transactions in the genesis block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/fa0e5934737e3048e4ada1a0ea6249381431c884"><pre>Merge tezos/tezos!8909: EVM/Kernel: store the transaction objects for the genesis block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0ff78a5f351774b0320b7a21e3a840a14f45c252"><pre>environment: introduce environment_protocol_T_V10</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2ad28481d53c36d83d5d0284b5b46d40099e14fa"><pre>environment: introduce encoding_with_legacy_attestation_name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9b50918d43cd1e8aca17ade3c977728e79dcdac3"><pre>proto: use lifted protocols when using block_services functor</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/61fef700acca2cda61253ac7e06b491cb3989b1f"><pre>lib_shell: block_services requires encoding with legacy attestation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bd785d7fd962bf29e912835d71618c4c08fa92f4"><pre>shell: use encoding with legacy attestation name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d3945cf53ddacf6c72affa0efaec1b3c271356bc"><pre>lib_mockup: use encoding with legacy attestation name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cfce4146f3aaada0a4bb2d1f0f2a5e834a0ee910"><pre>proto_alpha: non legacy encoding use encoding with attestation name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2d547346a7328675544b15e5dc164e75a65c393a"><pre>Changes: add env entry for encoding with legacy attestation name</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a5620c1f9ad333fc9c8024361a26a2bca5fde998"><pre>Merge tezos/tezos!8620: introduce encoding_with_legacy_attestation_name functions in environment</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4ebc09d8b71a39f03a48f182e0a309cb95988b9d"><pre>WASM/Debugger: fix \`step inbox\` tick and level counting</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9c4b572a673e29381f36082366380e0169173505"><pre>Merge tezos/tezos!8703: WASM/Debugger: fix \`step inbox\` tick and level counting</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4ec2294a3ff809d3efd663c271be474d3fe5c2ce"><pre>Injector: fix operation\'s uniqueness</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1a39b3c8960cbde4d9aea5956ff93fd375f6f2ae"><pre>Tezt: revert invalid test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/56a835f83124fc5d1dfd255aeaabbf76f3aade5d"><pre>Merge tezos/tezos!8929: Injector: fix operation\'s uniqueness</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ee6850c5ae7113dd4728dc7692e79cdae2b9396a"><pre>Scoru,Node: read durable storage after simulation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ba8112a296dcd82ee6d5444ba6ed01579f06640a"><pre>SCORU/Node/Mumbai: backport !8869</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c9a171ab63405bc73ebfd72665ee9ea470ffb83f"><pre>SCORU/Node/Nairobi: backport !8869</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3d6a349fb8fa6e2cb1a94f747346e03e43acd996"><pre>Merge tezos/tezos!8869: Scoru,Node: read durable storage after simulation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/26434f51e0c7a4085c1786dbe8076d74dbf902fc"><pre>p2p: reduce log default verbosity for some tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/18aa39299e763dc6d602413708c8ceef43aacdf1"><pre>Merge tezos/tezos!8636: p2p: reduce log default verbosity for some tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6e257a135468c2de75613d58427f8c77176dfa52"><pre>Scoru: remove commitment from cement operation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0da9b68ef1b425a548e996e94c21dccd1213df93"><pre>Merge tezos/tezos!8850: Scoru: remove commitment from cement operation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a6582422e47631a03ef5f62e0deb290e48018e13"><pre>EVM/Kernel: unify durable storage\'s paths under a single key</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f9db1dc9c2613d1d46781d8ebb79a2de31b218ab"><pre>EVM/Proxy: readapt proxy\'s rpcs and tests accordingly</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1768b58a2a68389856822c9448efdba4a9bf67b1"><pre>Merge tezos/tezos!8932: EVM/Kernel: unify durable storage\'s paths under a single key</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b6c7965338d90bf8136eb3344747c0c4c99be666"><pre>Proto/Alpha: add consensus key\'s public key in RPC</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/22c932725855f8ab81339dbb50e003aca323d184"><pre>Changes: add entry</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0c9cfa369e5df0e006448a60aa5710bba3373df2"><pre>Merge tezos/tezos!8856: Add consensus key\'s public key information in RPC</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/41874f9c2e31d60f5f63e7a3e1ec3869b8a2e817"><pre>ProxyServer: forward request to the node itself</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/accdd586733de671e273354089d53de3b5ed5e4c"><pre>Test/Proxy: unsupported endpoint are forwarded to the node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4fc25947f09124ad23cc9bebe627510bc91880b4"><pre>CHANGES: Proxy server can be the only visible endpoint</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/03259855b7def94c051bbc741dbb8d75fbd77bda"><pre>Merge tezos/tezos!8672: ProxyServer: forward request to the node itself</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cf7697172135de63710a90bcacacaadacc84b8b6"><pre>Chain_validator: broadcast only head when switching head</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e90fed83dd840d855d69657f387bbb5ea736f7a0"><pre>Merge tezos/tezos!8677: Chain_validator: broadcast only head when switching head</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/635390f35966c8f621da9ce40ffd838e00f0833c"><pre>Shell/bounding: indicate which operation needs to be overtaken</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0fcaedc986ab34c496338ac27e87c0f9cdb7449b"><pre>Shell: indicate needed fee to be included when an operation is</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/556512cceabd6b50b86c52d5a3f1e7fec2883c44"><pre>Tezt: update msg rejected_by_full_mempool and check indicated fee</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9923af31ec162dfc078455fbed810c1128d09ff6"><pre>Changelog: update entry on rejected_by_full_mempool error</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/def24fa242be3bed9d63f07eb3b5e0483c067b49"><pre>Merge tezos/tezos!8640: Shell: mempool: indicate needed fees to be considered by full mempool</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a45a66e5d6a54e5f113b5499817efeaa45fef9d9"><pre>Snoop: Fix \`inferred models\`</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1d132d2232b9a782bdd0ec7d5f1ddf12e9033570"><pre>Tezt/snoop: Update lsl_bytes.ml.expected</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f96947eaf457af76df21b9da1fe65f675feded85"><pre>Snoop: Modify found_codegen_models</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a87bbd2826adf2eed552e2509acb701784c1a326"><pre>Merge tezos/tezos!8605: Snoop: Fix \`inferred models\`</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a4f2b66cba06b8ac87dcf704b24808a6df4c03fe"><pre>EVM/Proxy: blocks can support full transactions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cd79df56f80f513ccdfe815ee1902212fb8b46a1"><pre>EVM/Proxy: fix block encoding</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f294fff4d9f02a75b398f94a57e97edc5ae99613"><pre>EVM/Proxy: fetch full blocks from rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c0a672c22bde2856f9be4883abc131151db22f7d"><pre>EVM/Test: block representation with full transactions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/efa23a88e07597acfe4b2d49ac6a00672c72a3bc"><pre>EVM/Tests: test \`eth_getBlockByNumber\` with full transactions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9b91cb29cf220196bc0f493b4be18e32783697d0"><pre>Merge tezos/tezos!8912: EVM/Proxy: fetch full blocks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/74fc374612ccaef4226f3bdc2b8203d279bd38d0"><pre>proto-alpha: slashing depends on staking-over-baking-limit</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d254a8efd598f3802f437b9716cbca2a79eb0bf2"><pre>Merge tezos/tezos!8939: proto-alpha: slashing depends on staking-over-baking-limit</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a57e1063e86668607c94513d97aa5a4b1b49af20"><pre>EVM on WASM: Add support for logging instructions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7170d574bb86c56c5e288622d7bcd1172cb2c0ca"><pre>Merge tezos/tezos!8721: EVM on WASM: Support logging instructions</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e19724c1511aee94c6d036aec46ef6a37b8655b9"><pre>Proto: Adaptive inflation: renamings for adding toggle vote</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cbc9800d9376adbf07eae86da4044c56f1c8a829"><pre>Proto: Adaptive inflation: add toggle vote</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/1b18b254c33f87f0d9d98ac6c1acbb105302966f"><pre>Proto: Adaptive inflation: update tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e44f44f20346b0d2d5bb0b4b9861c213f2b8e1f9"><pre>Proto: Adaptive inflation: update docs</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4403045dd00259b1e794a99b8a53418e241eecfe"><pre>Merge tezos/tezos!8661: Adaptive inflation: add new per block toggle vote</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/cfe4e96c71171d6adaa2dbb8d4b5594abe2b6f29"><pre>SCORU/Node: L1 block cache size configuration</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/aefe080fe955fc0edd066bf887d06990ad48150b"><pre>SCORU/Node: Configuration for prefetching of blocks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/835308f14d149ed7287b88e83866d5b4aee7ecb7"><pre>SCORU/Node/Mumbai: use blocks cache when fetching headers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3b9b4df45112cef6bb0942d971625a78b874d430"><pre>SCORU/Node/Mumbai: use configurable L1 cache size</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4684524f1650c0494d67bfec18d066b0a3606fa3"><pre>SCORU/Node/Mumbai: prefetch Tezos blocks</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/73fadbe99d61eede0d91436d5c7af00291e4f95a"><pre>SCORU/Node/Mumbai: show processing time of blocks in events</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9c70e533173b78384b1510d001fb45746e38851f"><pre>SCORU/Node/Mumbai: only check inbox for commitments when catching up</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7339416325c1fec3c74f678a2134e435dfe0cd34"><pre>SCORU/Node/Nairobi: port !8767 to Nairobi rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/33f0f91507cf5b5a32babe8859d1df2da6df6dc7"><pre>SCORU/Node/Alpha: port !8767 to Alpha rollup node</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3e3e08c982f556e4feecee58f9937c58216c775e"><pre>Doc: changelog</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c386827287756627047c74faf48abd6908854311"><pre>Merge tezos/tezos!8767: SCORU/Node: faster catching up on long histories</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2b99b467e844e3edb0cda34e097cfa12c03cad09"><pre>lib_plompiler lang_core circuit result: introduce [fmap]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bfc76a54ca3d15dbab9bbebc4827b43601512e21"><pre>lib_plonk test_plompiler: restructure tests</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/aabe426fe0e8255486b98aea30aba4a3d9a40489"><pre>lib_plompiler gadget_mod_arith: implement [constant], [zero], [one]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6e39849ef53647a45ddfee00e33ce504b005820c"><pre>lib_plompiler: implement modular subtraction based on mod_add</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/040764373524c7d41d690aa3c1ceb67c7633ecba"><pre>lib_plompiler gadget_mod_arith: implement [neg]</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9d14e56cd97612aa55d643c1e48604a1024b6668"><pre>PlonK & aPlonK: promote slow regression</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6739bdd65e2540cf3d0e62eb8c1eca16c57f6ba3"><pre>Merge tezos/tezos!8858: Modular subtraction and modular negation</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c6f23a89c5950b75ebac7ed483509b4a151e14fb"><pre>Shell: reduce the log level of headers fetching while bootstrapping</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bd0e56d0f702e07764d0458a8a0fad42259a841e"><pre>Shell: make the fetching branch event fit on one line</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2037f53d6c920d399442461ddf3083244f74827b"><pre>Merge tezos/tezos!8954: Reduce fetching headers log level</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bd9db6dd4308e461a0ed559d77e59ba264f145e5"><pre>Build: Fix make build-kernels</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c7362e621783df071d40b9a16e91dd4f94747286"><pre>Merge tezos/tezos!8935: Build: Fix make build-kernels</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/097c44a53a6ae5e56856c2bfbe805d45fa5c8f4a"><pre>Proto: Add Storage for dynamic rewards</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3266e25d5f77eba050504b57813ff85067ffb73d"><pre>Proto: clear outdated reward bonus</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4fd64406b2d1e926e2122158db8e6640a2c7e8f8"><pre>Proto: get reward bonus</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/26a15c1c6944ce7ae7b6e524c1c344deafc7f8ea"><pre>Proto/AI: add dummy compute bonus</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/506e39f66031529e8fe66646576175e2cd0048d8"><pre>Proto/AI: add reward bonus to storage and coeff</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/686e7454f7c62a682d72ed35c6adc2c6726e22ad"><pre>Proto/AI: minor refactor</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/43b2cf5b01a57c4bda8d7e1035502bbb6230b45b"><pre>Proto/AI: implement bonus reward</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/6b99be9ea0317c59fe0ef2818bcc20c11bfe692f"><pre>Merge tezos/tezos!8861: Proto/AI: Add Dynamic value to reward coefficient</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/e9afade31cf2c8fba61b5e48d852bb65ccbec6c2"><pre>CI: create folder for [unified_coverage]\'s log file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/74fb39a3bd2ac3cb406138a161a2b18b58e6a38c"><pre>Merge tezos/tezos!8953: CI: create folder for [unified_coverage]\'s log file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7cf40530ce5fc63eebde6402452d0e1fd137f1f0"><pre>Kernel/SDK: reboot kernel-installer</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ae12e4d5c69122c47b3626d115fcc071d15a09a1"><pre>Merge tezos/tezos!8934: Kernel/SDK: reboot kernel-installer</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0aac1ecf74badfbb7438883c586fe1ea006e684c"><pre>DAC: abstract RPC.call inside dac_rpc.ml</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d773456690d6ab1f0e43e0d523c00ebfbe60c2be"><pre>DAC: move helpers to dac_helper as simple syntactic sugar</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/56d487a67a6ab0201b32b9cb7b8d7ff432e66aed"><pre>Merge tezos/tezos!8862: DAC: abstract RPC.call inside dac_rpc.ml</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/4bf0573921584385099c6553fa0f939e8f52206c"><pre>Gossipsub/Test: Extract limits to separate file</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b82c3a63d6bbdb9e23dc8ffdd9122b7b1b10521f"><pre>Gossipsub/Test: Expose Message_cache.seen_message for testing</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/ce7aa10d0a81bd8d1733a0f8b5de84b2613d50ed"><pre>Gossipsub/Test: Add parameters to add_peer pbt generator</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bb7e67fff54596507f99751639f1bd5b8f770ebf"><pre>Gossipsub/Test: Move pp_output definition</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2317500267e08ab863c66e9b6bbea78d62709fbc"><pre>Gossipsub/Test: Expose peer score for testing</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/739e7a1f02d7c0788f062a418b963b363dd69230"><pre>Gosspipsub/Test: Expose more functions for testing</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9528916b19d9e4714cb647e920e9d158a9806c19"><pre>Gossipsub/Test: Add PBT for IHave handling</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/79383ea7c279172d344839f0e278ad1e6eefbfc1"><pre>Merge tezos/tezos!8826: Gossipsub/Test: Add PBT for handling IHaves</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/2f689554ef6d8aa26fd85ed54a6e1f4e9483ea26"><pre>Plugins: add find_manager function</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3bb5fd3b71db3e2cc6fafb42a8679cbf206151f0"><pre>Shell: maintain a map of manager operations indexed by manager</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/0df58f6080b6b12499c0b94efc9f28271bd35102"><pre>Merge tezos/tezos!8699: Mempool: maintain a map of manager operations indexed by manager</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/9d05c65b848f362c3758c957eeb98354a12583cf"><pre>Benchmarks_proto: removes 2 sapling benchmarks which caused ambiguities</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/dfb593e335503442df8d74540f3c3f94fbf3e854"><pre>Merge tezos/tezos!8773: Benchmarks_proto: removes Sapling_no_inputs and Sapling_no_outputs which cause...</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d7d0fdbbbc5d7f34f95a248db179c0958b96ece9"><pre>Snoop: add group to proto_alpha/lib_benchmarks_proto</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/d9d1916df94eb01d9bbfef0186c6005039029e8d"><pre>Merge tezos/tezos!8541: Snoop: add benchmark groups</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/3d1d02aba31856519b57e8702608cd6ea7eab2f1"><pre>Tezt/Snoop: adds missing tags</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/a15777fbbad60e409812364eeddffc1fc48b71a4"><pre>Tezt/Snoop: updates benchmark+inference targets</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/72fbb581c399f29520990d9c7d8f6a748c93d7ca"><pre>Tezt/Snoop: performs sapling/SAPING_APPLY_DIFF</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/186cc9907187d002e2bfdbef1a7af3bf0b3ea51d"><pre>Merge tezos/tezos!8803: Tezt/Snoop: adds inference of apply/Take_fees, micheline/strip_locations, and...</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/021a287006bce634914a7968819e0c2a2b8d1a08"><pre>Benchmark.Codegen: fixes printing</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/c6b2f2d16b06ebbd28a3099e9df07360bfd401f7"><pre>Fixes an expect test</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/69011f88611fc7d91d56a64d4ded2916f8566bc2"><pre>Tezt: fixes regression test data</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/b24beff59615dcd1612e11878507645231a01571"><pre>Merge tezos/tezos!7981: Benchmark.Codegen: fixes codegen printers</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/815bdcea44f7a637db279b274f38d7f1b847b8ef"><pre>EVM/Proxy: fix block mockup values</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/33a3033e105fd9b247233566faa06b5ed8aa67e9"><pre>EVM/Proxy: fix fetching of block hash for \`latest\` block</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/7172b6f0ad45798019432a6110bd4130b6070fab"><pre>EVM/Proxy: eth_call: \`to\` can be null</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/70eebc1ab385e2804c44ca8a1df869df3bf236d6"><pre>Merge tezos/tezos!8917: EVM/Proxy: collection of small bugfixes</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/f238f11b0b7283c109bacb216ca9f4fa0f72109e"><pre>Gossipsub/Test: Reogranize default_limits.ml, add arguments</pre></a>
* <a href="https://gitlab.com/tezos/tezos/-/commit/bdd90c13bc93379d7d10eab02235f41807f09963"><pre>Merge tezos/tezos!8938: Gossipsub/Test: Reorganize default_limits.ml</pre></a>

#### Diff URL: https://gitlab.com/tezos/tezos/-/compare/a948d637d5506619e41573e1a1df65ab5f84faf0...bdd90c13bc93379d7d10eab02235f41807f09963